### PR TITLE
Add AMD_TRITON_NPU_TARGET env var for cross-compilation

### DIFF
--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -191,7 +191,20 @@ NPU_MODELS = {
 
 
 def detect_npu_version():
-    """Map known device names to internal NPU version strings."""
+    """Map known device names to internal NPU version strings.
+
+    If AMD_TRITON_NPU_TARGET is set, use that value directly
+    (must be 'npu1' or 'npu2'). This enables cross-compilation
+    without local NPU hardware.
+    """
+    target = os.getenv("AMD_TRITON_NPU_TARGET", "").lower()
+    if target:
+        if target not in NPU_MODELS:
+            raise RuntimeError(
+                f"Invalid AMD_TRITON_NPU_TARGET='{target}'. "
+                f"Supported values: {list(NPU_MODELS.keys())}"
+            )
+        return target
     devices = get_npu_device_info()
     for device in devices:
         name = device["name"]


### PR DESCRIPTION
## Summary
- Adds `AMD_TRITON_NPU_TARGET` environment variable (`npu1` or `npu2`) that overrides hardware detection in `detect_npu_version()`, skipping the `xrt-smi` query entirely
- Enables `AMD_TRITON_NPU_COMPILE_ONLY=1` to work on machines without a matching local NPU device (cross-compilation)
- Invalid values produce a clear `RuntimeError` with supported options

Closes #42

## Test plan
- [x] Verify `AMD_TRITON_NPU_TARGET=npu2 AMD_TRITON_NPU_COMPILE_ONLY=1 python examples/vec-add/vec-add.py` compiles without querying `xrt-smi`
- [x] Verify `AMD_TRITON_NPU_TARGET=npu3` raises `RuntimeError` with a clear message
- [x] Verify no regression: without `AMD_TRITON_NPU_TARGET` set, behavior is unchanged (auto-detect via `xrt-smi`)
- [x] Verify `AMD_TRITON_NPU_TARGET=npu1 AMD_TRITON_NPU_OUTPUT_FORMAT=elf` still raises the "ELF not supported on npu1" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)