### PR TITLE
Add Python config API for NPU backend settings

### DIFF
--- a/amd_triton_npu/backend/__init__.py
+++ b/amd_triton_npu/backend/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT

--- a/amd_triton_npu/backend/compiler.py
+++ b/amd_triton_npu/backend/compiler.py
@@ -15,6 +15,8 @@ import subprocess
 import functools
 from pathlib import Path
 
+from .config import npu_config
+
 
 def _get_amd_triton_npu_opt_path() -> str:
     path = (
@@ -34,30 +36,14 @@ def _get_llvm_bin_path(bin_name: str) -> str:
     return os.path.join(path, bin_name)
 
 
-def _get_air_project_path():
-    """
-    Get the path for air_project directory.
-
-    If AMD_TRITON_NPU_AIR_PROJECT_PATH is set, use that path.
-    Otherwise, default to 'air_project' in the current working directory.
-
-    Returns:
-        Path: The path to the air_project directory
-    """
-    custom_path = os.getenv("AMD_TRITON_NPU_AIR_PROJECT_PATH")
-    if custom_path:
-        return Path(custom_path)
-    return Path(os.getcwd()) / "air_project"
-
-
 def _dump_ir_if_needed(files):
     """
     Dump intermediate IR files to the air_project directory.
 
     Files are always dumped to the air_project path (controlled by
-    AMD_TRITON_NPU_AIR_PROJECT_PATH or defaulting to ./air_project/).
+    ``npu_config.air_project_path`` or defaulting to ./air_project/).
     """
-    air_proj_path = _get_air_project_path()
+    air_proj_path = npu_config.air_project_path
     os.makedirs(air_proj_path, exist_ok=True)
     for f in files:
         shutil.copy(f, os.path.join(air_proj_path, os.path.basename(f)))

--- a/amd_triton_npu/backend/config.py
+++ b/amd_triton_npu/backend/config.py
@@ -148,6 +148,9 @@ class _NPUConfig:
 
     @air_project_path.setter
     def air_project_path(self, value):
+        if value is None:
+            self._air_project_path = _UNSET
+            return
         self._air_project_path = value
 
     # ---- utilities ----
@@ -198,16 +201,10 @@ def config_context(**kwargs):
         with config_context(compile_only=True):
             kernel[grid](a, b, c)
     """
-    saved = {
-        "_compile_only": npu_config._compile_only,
-        "_transform_tiling_script": npu_config._transform_tiling_script,
-        "_bf16_emulation": npu_config._bf16_emulation,
-        "_output_format": npu_config._output_format,
-        "_air_project_path": npu_config._air_project_path,
-    }
+    saved = npu_config.__dict__.copy()
     try:
         set_config(**kwargs)
         yield npu_config
     finally:
-        for attr, val in saved.items():
-            object.__setattr__(npu_config, attr, val)
+        npu_config.__dict__.clear()
+        npu_config.__dict__.update(saved)

--- a/amd_triton_npu/backend/config.py
+++ b/amd_triton_npu/backend/config.py
@@ -1,0 +1,213 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+Process-global configuration for the Triton-XDNA NPU backend.
+
+Provides a Python API to control settings that were previously only
+available via environment variables. Programmatic values always take
+priority over environment variables, which in turn take priority over
+built-in defaults.
+
+Usage::
+
+    from triton.backends.amd_triton_npu.config import npu_config, set_config
+
+    # Direct attribute assignment
+    npu_config.bf16_emulation = True
+    npu_config.compile_only = True
+
+    # Or dict-style
+    set_config(bf16_emulation=True, compile_only=False)
+
+    # Temporary overrides via context manager
+    from triton.backends.amd_triton_npu.config import config_context
+    with config_context(compile_only=True):
+        kernel[grid](a, b, c)
+
+    # Environment variables still work as fallback
+    # AMD_TRITON_NPU_BF16_EMULATION=1 python my_script.py
+"""
+
+import contextlib
+import os
+from pathlib import Path
+
+_UNSET = object()
+
+
+class _NPUConfig:
+    """Process-global configuration for the NPU backend.
+
+    Each property falls back to its corresponding environment variable
+    when no programmatic value has been set. Call ``reset()`` to clear
+    all programmatic overrides.
+    """
+
+    def __init__(self):
+        self._compile_only = _UNSET
+        self._transform_tiling_script = _UNSET
+        self._bf16_emulation = _UNSET
+        self._output_format = _UNSET
+        self._air_project_path = _UNSET
+
+    # ---- compile_only ----
+
+    @property
+    def compile_only(self) -> bool:
+        """If True, compile kernels but skip XRT launch.
+
+        Env var fallback: ``AMD_TRITON_NPU_COMPILE_ONLY`` (``"1"`` to enable).
+        """
+        if self._compile_only is not _UNSET:
+            return self._compile_only
+        return os.getenv("AMD_TRITON_NPU_COMPILE_ONLY", "0") == "1"
+
+    @compile_only.setter
+    def compile_only(self, value: bool):
+        self._compile_only = bool(value)
+
+    # ---- transform_tiling_script ----
+
+    @property
+    def transform_tiling_script(self):
+        """Path to a custom MLIR Transform dialect tiling script.
+
+        When set, the backend loads this file instead of the built-in
+        default tiling strategy. Set to ``None`` to use the default.
+
+        Env var fallback: ``AIR_TRANSFORM_TILING_SCRIPT``.
+        """
+        if self._transform_tiling_script is not _UNSET:
+            return self._transform_tiling_script
+        return os.getenv("AIR_TRANSFORM_TILING_SCRIPT")
+
+    @transform_tiling_script.setter
+    def transform_tiling_script(self, value):
+        self._transform_tiling_script = value
+
+    # ---- bf16_emulation ----
+
+    @property
+    def bf16_emulation(self) -> bool:
+        """If True, pass ``--bf16-emulation`` to aircc.
+
+        This enables hardware truncation of f32 to bf16 before multiply,
+        with f32 accumulation.
+
+        Env var fallback: ``AMD_TRITON_NPU_BF16_EMULATION`` (``"1"`` to enable).
+        """
+        if self._bf16_emulation is not _UNSET:
+            return self._bf16_emulation
+        return os.getenv("AMD_TRITON_NPU_BF16_EMULATION", "0") == "1"
+
+    @bf16_emulation.setter
+    def bf16_emulation(self, value: bool):
+        self._bf16_emulation = bool(value)
+
+    # ---- output_format ----
+
+    @property
+    def output_format(self):
+        """Force the output format to ``"elf"`` or ``"xclbin"``.
+
+        Set to ``None`` for auto-detection (ELF on npu2, xclbin on npu1).
+        ELF format is only supported on npu2 (AIE2P) devices.
+
+        Env var fallback: ``AMD_TRITON_NPU_OUTPUT_FORMAT``.
+        """
+        if self._output_format is not _UNSET:
+            return self._output_format
+        v = os.getenv("AMD_TRITON_NPU_OUTPUT_FORMAT", "").lower()
+        return v if v in ("elf", "xclbin") else None
+
+    @output_format.setter
+    def output_format(self, value):
+        if value is not None and value not in ("elf", "xclbin"):
+            raise ValueError(
+                f"output_format must be 'elf', 'xclbin', or None; got {value!r}"
+            )
+        self._output_format = value
+
+    # ---- air_project_path ----
+
+    @property
+    def air_project_path(self) -> Path:
+        """Directory where intermediate IR files and compiled artifacts are written.
+
+        Defaults to ``./air_project/`` relative to the current working directory.
+
+        Env var fallback: ``AMD_TRITON_NPU_AIR_PROJECT_PATH``.
+        """
+        if self._air_project_path is not _UNSET:
+            return Path(self._air_project_path)
+        custom = os.getenv("AMD_TRITON_NPU_AIR_PROJECT_PATH")
+        if custom:
+            return Path(custom)
+        return Path(os.getcwd()) / "air_project"
+
+    @air_project_path.setter
+    def air_project_path(self, value):
+        self._air_project_path = value
+
+    # ---- utilities ----
+
+    def reset(self):
+        """Clear all programmatic overrides, reverting to env var / default values."""
+        self._compile_only = _UNSET
+        self._transform_tiling_script = _UNSET
+        self._bf16_emulation = _UNSET
+        self._output_format = _UNSET
+        self._air_project_path = _UNSET
+
+
+# Module-level singleton
+npu_config = _NPUConfig()
+
+
+def set_config(**kwargs):
+    """Set multiple configuration options at once.
+
+    Example::
+
+        set_config(compile_only=True, bf16_emulation=True)
+
+    Raises ``ValueError`` for unknown keys.
+    """
+    valid_keys = {
+        "compile_only",
+        "transform_tiling_script",
+        "bf16_emulation",
+        "output_format",
+        "air_project_path",
+    }
+    for key, value in kwargs.items():
+        if key not in valid_keys:
+            raise ValueError(
+                f"Unknown config key: {key!r}. Valid keys: {sorted(valid_keys)}"
+            )
+        setattr(npu_config, key, value)
+
+
+@contextlib.contextmanager
+def config_context(**kwargs):
+    """Temporarily override configuration settings, restoring on exit.
+
+    Example::
+
+        with config_context(compile_only=True):
+            kernel[grid](a, b, c)
+    """
+    saved = {
+        "_compile_only": npu_config._compile_only,
+        "_transform_tiling_script": npu_config._transform_tiling_script,
+        "_bf16_emulation": npu_config._bf16_emulation,
+        "_output_format": npu_config._output_format,
+        "_air_project_path": npu_config._air_project_path,
+    }
+    try:
+        set_config(**kwargs)
+        yield npu_config
+    finally:
+        for attr, val in saved.items():
+            object.__setattr__(npu_config, attr, val)

--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -24,6 +24,8 @@ from air.compiler.util import run_transform
 from air.ir import *
 import air.passmanager
 
+from .config import npu_config
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.CRITICAL)
 if os.getenv("AMD_TRITON_NPU_DEBUG", "0") == "1":
@@ -131,30 +133,14 @@ def _get_aie_test_utils_path() -> str:
     return path
 
 
-def _get_air_project_path() -> Path:
-    """
-    Get the path for air_project directory.
-
-    If AMD_TRITON_NPU_AIR_PROJECT_PATH is set, use that path.
-    Otherwise, default to 'air_project' in the current working directory.
-
-    Returns:
-        Path: The path to the air_project directory
-    """
-    custom_path = os.getenv("AMD_TRITON_NPU_AIR_PROJECT_PATH")
-    if custom_path:
-        return Path(custom_path)
-    return Path(os.getcwd()) / "air_project"
-
-
 def _dump_ir_if_needed(files):
     """
     Dump intermediate IR files to the air_project directory.
 
     Files are always dumped to the air_project path (controlled by
-    AMD_TRITON_NPU_AIR_PROJECT_PATH or defaulting to ./air_project/).
+    ``npu_config.air_project_path`` or defaulting to ./air_project/).
     """
-    air_proj_path = _get_air_project_path()
+    air_proj_path = npu_config.air_project_path
     os.makedirs(air_proj_path, exist_ok=True)
     for f in files:
         shutil.copy(f, os.path.join(air_proj_path, os.path.basename(f)))
@@ -236,19 +222,20 @@ def detect_npu_version():
 def _get_output_format():
     """Determine the output format for the NPU backend.
 
-    Checks AMD_TRITON_NPU_OUTPUT_FORMAT env var first.
+    Checks ``npu_config.output_format`` first (which itself falls back to
+    the ``AMD_TRITON_NPU_OUTPUT_FORMAT`` env var).
     If not set, defaults to "elf" on npu2 and "xclbin" on npu1.
     ELF format is only supported on npu2 (AIE2P) devices.
     """
     npu_version = detect_npu_version()
-    env_format = os.getenv("AMD_TRITON_NPU_OUTPUT_FORMAT", "").lower()
-    if env_format in ("elf", "xclbin"):
-        if env_format == "elf" and npu_version == "npu1":
+    configured_format = npu_config.output_format
+    if configured_format is not None:
+        if configured_format == "elf" and npu_version == "npu1":
             raise RuntimeError(
                 "ELF output format is not supported on npu1 (AIE2) devices. "
-                "Use 'xclbin' or unset AMD_TRITON_NPU_OUTPUT_FORMAT."
+                "Use 'xclbin' or set npu_config.output_format = None."
             )
-        return env_format
+        return configured_format
     # Auto-detect: ELF for npu2, xclbin for npu1
     return "elf" if npu_version == "npu2" else "xclbin"
 
@@ -438,9 +425,9 @@ def _get_transform_ir_string():
     """
     Get the transform IR string for tiling operations.
 
-    If the environment variable AIR_TRANSFORM_TILING_SCRIPT is set,
-    read the transform IR from that file. Otherwise, use the default
-    hardcoded transform IR string.
+    If ``npu_config.transform_tiling_script`` is set (or the
+    ``AIR_TRANSFORM_TILING_SCRIPT`` env var), read the transform IR from
+    that file. Otherwise, use the default hardcoded transform IR string.
 
     If the script uses `transform.include`, the shared transform library
     (transform_library.mlir) is automatically injected.
@@ -448,12 +435,12 @@ def _get_transform_ir_string():
     Returns:
         str: The transform IR string to use for tiling
     """
-    custom_script_path = os.getenv("AIR_TRANSFORM_TILING_SCRIPT")
+    custom_script_path = npu_config.transform_tiling_script
 
     if custom_script_path:
         if not os.path.isfile(custom_script_path):
             raise FileNotFoundError(
-                f"AIR_TRANSFORM_TILING_SCRIPT is set to '{custom_script_path}' "
+                f"transform_tiling_script is set to '{custom_script_path}' "
                 f"but the file was not found (cwd: {os.getcwd()}). "
                 f"Use an absolute path or run from the directory containing the script."
             )
@@ -1222,9 +1209,7 @@ def compile_module(
         kernel_name = kernel_metadata[6]  # see pack_metadata in compiler.py
         src = launcher_src.replace(kernel_placeholder_name, kernel_name)
 
-        # Get air_project path (controlled by AMD_TRITON_NPU_AIR_PROJECT_PATH
-        # or defaults to ./air_project/)
-        air_proj_path = _get_air_project_path()
+        air_proj_path = npu_config.air_project_path
         os.makedirs(air_proj_path, exist_ok=True)
         Path(os.path.join(air_proj_path, "asm_src.mlir")).write_bytes(asm_src)
         air_output = _ttshared_to_air(
@@ -1239,7 +1224,7 @@ def compile_module(
             + f"_timing_{autotune_time}"
             + f"_format_{output_format}"
             + f"_npu_{npu_version}"
-            + f"_bf16emu_{os.getenv('AMD_TRITON_NPU_BF16_EMULATION', '0')}"
+            + f"_bf16emu_{npu_config.bf16_emulation}"
         )
         key = hashlib.md5(key_data.encode("utf-8")).hexdigest()
 
@@ -1331,7 +1316,7 @@ def compile_module(
                     ]
                 # Enable bf16 emulation: hardware truncates f32 -> bf16 before
                 # multiply, with f32 accumulation.
-                if os.getenv("AMD_TRITON_NPU_BF16_EMULATION", "0") == "1":
+                if npu_config.bf16_emulation:
                     aircc_cmd.insert(-1, "--bf16-emulation")
                 # Explicitly set runtime loop tiling sizes to [4,4] (aircc
                 # default changed from [4,4] to [] in mlir-air #1470).
@@ -1364,7 +1349,7 @@ def compile_module(
                     cache_path = cache.put(f.read(), filename, binary=True)
 
                 # Check for compile-only mode
-                if os.getenv("AMD_TRITON_NPU_COMPILE_ONLY", "0") == "1":
+                if npu_config.compile_only:
                     logger.debug("Compile-only mode: binaries cached at %s", cache_path)
                     if output_format == "elf":
                         logger.debug("  elf: %s", cache_elf_path)
@@ -1380,7 +1365,7 @@ def compile_module(
             )
 
             # Check for compile-only mode (cache hit)
-            if os.getenv("AMD_TRITON_NPU_COMPILE_ONLY", "0") == "1":
+            if npu_config.compile_only:
                 logger.debug(
                     "Compile-only mode (cache hit): binaries at %s", cache_path
                 )

--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -233,7 +233,8 @@ def _get_output_format():
         if configured_format == "elf" and npu_version == "npu1":
             raise RuntimeError(
                 "ELF output format is not supported on npu1 (AIE2) devices. "
-                "Use 'xclbin' or set npu_config.output_format = None."
+                "Unset or change AMD_TRITON_NPU_OUTPUT_FORMAT, or set "
+                "npu_config.output_format to 'xclbin' or None."
             )
         return configured_format
     # Auto-detect: ELF for npu2, xclbin for npu1
@@ -440,9 +441,10 @@ def _get_transform_ir_string():
     if custom_script_path:
         if not os.path.isfile(custom_script_path):
             raise FileNotFoundError(
-                f"transform_tiling_script is set to '{custom_script_path}' "
-                f"but the file was not found (cwd: {os.getcwd()}). "
-                f"Use an absolute path or run from the directory containing the script."
+                f"transform_tiling_script / AIR_TRANSFORM_TILING_SCRIPT is set to "
+                f"'{custom_script_path}' but the file was not found "
+                f"(cwd: {os.getcwd()}). Use an absolute path or run from the "
+                f"directory containing the script."
             )
         with open(custom_script_path, "r") as f:
             logger.debug("Using custom tiling script from: %s", custom_script_path)


### PR DESCRIPTION
## Summary

- Adds `amd_triton_npu/backend/config.py` with a singleton `npu_config` object that provides programmatic control over 5 settings previously only available via environment variables
- Replaces all ad-hoc `os.getenv` calls in `driver.py` and `compiler.py` with reads from the config singleton
- Eliminates the duplicated `_get_air_project_path()` function that existed in both files

## API

```python
from triton.backends.amd_triton_npu.config import npu_config, set_config, config_context

# Direct attribute assignment
npu_config.bf16_emulation = True
npu_config.compile_only = True
npu_config.air_project_path = "/tmp/my_project"
npu_config.transform_tiling_script = "/path/to/tiling.mlir"
npu_config.output_format = "elf"  # or "xclbin" or None for auto-detect

# Dict-style
set_config(bf16_emulation=True, compile_only=False)

# Context manager for temporary overrides
with config_context(compile_only=True):
    kernel[grid](a, b, c)
```

All existing environment variables continue to work as fallback defaults — fully backward compatible.

| Config property | Env var fallback | Default |
|---|---|---|
| `compile_only` | `AMD_TRITON_NPU_COMPILE_ONLY` | `False` |
| `transform_tiling_script` | `AIR_TRANSFORM_TILING_SCRIPT` | `None` |
| `bf16_emulation` | `AMD_TRITON_NPU_BF16_EMULATION` | `False` |
| `output_format` | `AMD_TRITON_NPU_OUTPUT_FORMAT` | `None` (auto-detect) |
| `air_project_path` | `AMD_TRITON_NPU_AIR_PROJECT_PATH` | `./air_project` |

Closes #43

## Test plan

- [ ] Verify import works: `python -c "from triton.backends.amd_triton_npu.config import npu_config, set_config, config_context"`
- [ ] Verify env var fallback: `AMD_TRITON_NPU_COMPILE_ONLY=1 python -c "from triton.backends.amd_triton_npu.config import npu_config; assert npu_config.compile_only"`
- [ ] Verify programmatic override wins over env var: `AMD_TRITON_NPU_BF16_EMULATION=1 python -c "from triton.backends.amd_triton_npu.config import npu_config; npu_config.bf16_emulation = False; assert not npu_config.bf16_emulation"`
- [ ] Run existing examples with env vars to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)