### PR TITLE
Bump mlir-air to e279756 (fix i8 matmul compile time)

### DIFF
--- a/utils/mlir-air-hash.txt
+++ b/utils/mlir-air-hash.txt
@@ -1,3 +1,3 @@
-Commit: e8c63ed
-Timestamp: 2026040805
+Commit: e279756
+Timestamp: 2026041318
 Version: 0.0.1


### PR DESCRIPTION
## Summary
- Bump mlir-air dependency from `e8c63ed` to `e279756` to pick up [Xilinx/mlir-air#1531](https://github.com/Xilinx/mlir-air/pull/1531)
- Fixes column-aware L2 memref-to-memtile assignment in the `air-to-aie` pass that caused 18x compile time regression for i8 matmul with 8x4 herds
- The `matmul_i8_m128_n64_k64` example no longer times out in CI

## Root cause
The `L2MemrefToMemTileMap` function used blind round-robin to assign L2 buffers to memtile columns. When C-output allocs appeared after A/B-input allocs (as happens in the Triton pipeline), the counter wrapped and placed buffers on wrong columns, forcing `aie-create-pathfinder-flows` to solve expensive cross-column routing (~2m20s per compilation instead of <0.5s).

## Local profiling results (M=4096, N=2048, K=1024 i8 matmul, NPU2/Strix)

| Metric | Before (e8c63ed) | After (e279756) |
|--------|:-:|:-:|
| Single compilation | 171.25s | 9.34s |
| Full test suite (36 invocations) | >20min (timeout) | 2m42s |

Fixes #50

## Test plan
- [x] Single worst-case compilation profiled: 171.25s → 9.34s
- [x] Full `matmul_i8_m128_n64_k64` test suite passes within 20-min timeout (2m42s)
- [x] Correctness verified (all torch.testing.assert_close checks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)