### PR TITLE
Suppress debug output when AMD_TRITON_NPU_DEBUG is off

### DIFF
--- a/amd_triton_npu/backend/compiler.py
+++ b/amd_triton_npu/backend/compiler.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Tuple
 from types import ModuleType
 import hashlib
+import sys
 import tempfile
 import os
 import re
@@ -57,16 +58,26 @@ def _ttir_to_ttsharedir(mod):
         dst_path = os.path.join(tmpdir, "ttshared.mlir")
         Path(src_path).write_text(ttir_code)
         amd_triton_npu_opt_path = _get_amd_triton_npu_opt_path()
-        subprocess.check_call(
-            [
-                amd_triton_npu_opt_path,
-                src_path,
-                "--triton-to-linalg-experimental",
-                "--mlir-print-debuginfo",
-                "-o",
-                dst_path,
-            ]
-        )
+        cmd = [
+            amd_triton_npu_opt_path,
+            src_path,
+            "--triton-to-linalg-experimental",
+            "--mlir-print-debuginfo",
+            "-o",
+            dst_path,
+        ]
+        if npu_config.debug:
+            subprocess.check_call(cmd)
+        else:
+            result = subprocess.run(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+            if result.returncode != 0:
+                if result.stdout:
+                    sys.stderr.buffer.write(result.stdout)
+                raise subprocess.CalledProcessError(
+                    result.returncode, cmd, output=result.stdout
+                )
         _dump_ir_if_needed([src_path])
         return Path(dst_path).read_text()
 

--- a/amd_triton_npu/backend/compiler.py
+++ b/amd_triton_npu/backend/compiler.py
@@ -74,7 +74,13 @@ def _ttir_to_ttsharedir(mod):
             )
             if result.returncode != 0:
                 if result.stdout:
-                    sys.stderr.buffer.write(result.stdout)
+                    stderr_buf = getattr(sys.stderr, "buffer", None)
+                    if stderr_buf is not None:
+                        stderr_buf.write(result.stdout)
+                    else:
+                        sys.stderr.write(
+                            result.stdout.decode("utf-8", errors="replace")
+                        )
                 raise subprocess.CalledProcessError(
                     result.returncode, cmd, output=result.stdout
                 )

--- a/amd_triton_npu/backend/config.py
+++ b/amd_triton_npu/backend/config.py
@@ -30,6 +30,7 @@ Usage::
 """
 
 import contextlib
+import logging
 import os
 from pathlib import Path
 
@@ -169,6 +170,10 @@ class _NPUConfig:
     @debug.setter
     def debug(self, value: bool):
         self._debug = bool(value)
+        # Keep the driver logger level in sync so logger.debug() calls
+        # are enabled/suppressed when the flag is toggled programmatically.
+        _drv = logging.getLogger("triton.backends.amd_triton_npu.driver")
+        _drv.setLevel(logging.DEBUG if self._debug else logging.CRITICAL)
 
     # ---- utilities ----
 

--- a/amd_triton_npu/backend/config.py
+++ b/amd_triton_npu/backend/config.py
@@ -50,6 +50,7 @@ class _NPUConfig:
         self._bf16_emulation = _UNSET
         self._output_format = _UNSET
         self._air_project_path = _UNSET
+        self._debug = _UNSET
 
     # ---- compile_only ----
 
@@ -153,6 +154,22 @@ class _NPUConfig:
             return
         self._air_project_path = value
 
+    # ---- debug ----
+
+    @property
+    def debug(self) -> bool:
+        """If True, enable verbose logging from subprocesses and the C++ launcher.
+
+        Env var fallback: ``AMD_TRITON_NPU_DEBUG`` (``"1"`` to enable).
+        """
+        if self._debug is not _UNSET:
+            return self._debug
+        return os.getenv("AMD_TRITON_NPU_DEBUG", "0") == "1"
+
+    @debug.setter
+    def debug(self, value: bool):
+        self._debug = bool(value)
+
     # ---- utilities ----
 
     def reset(self):
@@ -162,6 +179,7 @@ class _NPUConfig:
         self._bf16_emulation = _UNSET
         self._output_format = _UNSET
         self._air_project_path = _UNSET
+        self._debug = _UNSET
 
 
 # Module-level singleton
@@ -179,6 +197,7 @@ def set_config(**kwargs):
     """
     valid_keys = {
         "compile_only",
+        "debug",
         "transform_tiling_script",
         "bf16_emulation",
         "output_format",

--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -1285,7 +1285,13 @@ def compile_module(
                     )
                     if result.returncode != 0:
                         if result.stdout:
-                            sys.stderr.buffer.write(result.stdout)
+                            stderr_buf = getattr(sys.stderr, "buffer", None)
+                            if stderr_buf is not None:
+                                stderr_buf.write(result.stdout)
+                            else:
+                                sys.stderr.write(
+                                    result.stdout.decode("utf-8", errors="replace")
+                                )
                         raise subprocess.CalledProcessError(
                             result.returncode,
                             compile_flags,
@@ -1349,7 +1355,13 @@ def compile_module(
                     )
                     if result.returncode != 0:
                         if result.stdout:
-                            sys.stderr.buffer.write(result.stdout)
+                            stderr_buf = getattr(sys.stderr, "buffer", None)
+                            if stderr_buf is not None:
+                                stderr_buf.write(result.stdout)
+                            else:
+                                sys.stderr.write(
+                                    result.stdout.decode("utf-8", errors="replace")
+                                )
                         raise subprocess.CalledProcessError(
                             result.returncode,
                             aircc_cmd,

--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -28,7 +28,7 @@ from .config import npu_config
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.CRITICAL)
-if os.getenv("AMD_TRITON_NPU_DEBUG", "0") == "1":
+if npu_config.debug:
     logger.setLevel(logging.DEBUG)
 if not logger.handlers:
     _handler = logging.StreamHandler()
@@ -606,7 +606,7 @@ static void _launch(int gridX, int gridY, int gridZ, {', '.join(f"long size{i}" 
     std::vector<uint32_t> instr_v =
         test_utils::load_instr_binary(insts_path);
 
-    int verbosity = 1;
+    int verbosity = {1 if npu_config.debug else 0};
     if (verbosity >= 1)
         std::cout << "Sequence instr count: " << instr_v.size() << std::endl;
 
@@ -627,9 +627,9 @@ static void _launch(int gridX, int gridY, int gridZ, {', '.join(f"long size{i}" 
     // Get the kernel from the xclbin
     auto xkernels = xclbin.get_kernels();
     auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
-                                    [Node](xrt::xclbin::kernel &k) {{
+                                    [Node, verbosity](xrt::xclbin::kernel &k) {{
                                     auto name = k.get_name();
-                                    std::cout << "Name: " << name << std::endl;
+                                    if (verbosity >= 1) std::cout << "Name: " << name << std::endl;
                                     return name.rfind(Node, 0) == 0;
                                     }});
     auto kernelName = xkernel.get_name();
@@ -939,7 +939,7 @@ static PyObject* py_set_paths(PyObject* self, PyObject* args) {{
 static void _launch(int gridX, int gridY, int gridZ, {', '.join(f"long size{i}" for i, ty in ptr_args)}, {arg_decls}) {{
   if (gridX*gridY*gridZ > 0) {{
 
-    int verbosity = 1;
+    int verbosity = {1 if npu_config.debug else 0};
 
     // Get a device handle
     unsigned int device_index = 0;
@@ -1275,7 +1275,22 @@ def compile_module(
                         "-ltest_utils",
                     ]
                 compile_flags += ["-o", so_path]
-                subprocess.check_call(compile_flags)
+                if npu_config.debug:
+                    subprocess.check_call(compile_flags)
+                else:
+                    result = subprocess.run(
+                        compile_flags,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )
+                    if result.returncode != 0:
+                        if result.stdout:
+                            sys.stderr.buffer.write(result.stdout)
+                        raise subprocess.CalledProcessError(
+                            result.returncode,
+                            compile_flags,
+                            output=result.stdout,
+                        )
 
                 ###### Compile to binary (ELF or xclbin + insts)
                 air_mlir_path = os.path.join(air_proj_path, "asm_air_output.mlir")
@@ -1324,7 +1339,22 @@ def compile_module(
                 # default changed from [4,4] to [] in mlir-air #1470).
                 aircc_cmd.insert(-1, "--air-runtime-loop-tiling-sizes=4")
                 aircc_cmd.insert(-1, "--air-runtime-loop-tiling-sizes=4")
-                subprocess.check_call(aircc_cmd)
+                if npu_config.debug:
+                    subprocess.check_call(aircc_cmd)
+                else:
+                    result = subprocess.run(
+                        aircc_cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )
+                    if result.returncode != 0:
+                        if result.stdout:
+                            sys.stderr.buffer.write(result.stdout)
+                        raise subprocess.CalledProcessError(
+                            result.returncode,
+                            aircc_cmd,
+                            output=result.stdout,
+                        )
 
                 # Cache format-specific artifacts first, then the .so last.
                 # This avoids partial cache entries if aircc or kernel name


### PR DESCRIPTION
## Summary

- Fixes #52: subprocess output (Bootgen/xclbinutil banners, `[INFO]` messages) and C++ launcher verbosity (`Loading ELF`, `Running Kernel`, etc.) were always printed regardless of the `AMD_TRITON_NPU_DEBUG` flag
- Adds `debug` property to `npu_config` (following the existing `_UNSET`-backed pattern) so it can be controlled both via env var and programmatically
- Captures stdout/stderr from `g++`, `aircc`, and `triton-shared-opt` subprocesses when not in debug mode; prints captured output to stderr on failure so error messages are never lost
- Sets C++ launcher `int verbosity` to `0`/`1` based on `npu_config.debug` in both `_generate_launcher()` (xclbin) and `_generate_elf_launcher()` (ELF)
- Guards a previously unguarded `std::cout` in the xclbin kernel-search lambda

## Test plan

- [x] Verified on NPU2 (Strix) with `examples/vec-add/`: no output when `AMD_TRITON_NPU_DEBUG` is unset
- [x] Verified on NPU2 (Strix) with `examples/vec-add/`: full verbose output when `AMD_TRITON_NPU_DEBUG=1`
- [x] CI build passes
- [ ] Verify error messages are still visible when a subprocess fails (e.g., missing `aiecc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)