### PR TITLE
Bump mlir-air to dfa6d08, drop mlir-aie-hash.txt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,9 @@ jobs:
           -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
           -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti \
           -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+      # The [aie] extra requires llvm-aie without a version pin. Force an
+      # upgrade so we always test against the latest nightly wheel.
+      python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
       python3 -m pip show llvm-aie
       python3 -m pip show mlir_aie
       # Set environmental variable "MLIR_AIE_INSTALL_DIR"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,20 +39,12 @@ jobs:
       pip install --upgrade pip
       pip install lit cmake joblib pybind11 nanobind
 
-   - name: Install MLIR-AIE with specified hash
+   - name: Install MLIR-AIR (with mlir-aie + llvm-aie via [aie] extra)
      shell: bash
      run: |
-      MLIR_AIE_COMMIT_HASH_FILE=utils/mlir-aie-hash.txt
-      # Install mlir-aie
-      MLIR_AIE_COMMIT_HASH=$(awk -v kw="Commit:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIE_COMMIT_HASH_FILE")
-      SHORT_MLIR_AIE_COMMIT_HASH="${MLIR_AIE_COMMIT_HASH:0:7}"
-      echo "Using mlir-aie hash: $SHORT_MLIR_AIE_COMMIT_HASH"
-      MLIR_AIE_VERSION=$(awk -v kw="Version:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIE_COMMIT_HASH_FILE")
-      echo "Version: $MLIR_AIE_VERSION"
-      TIMESTAMP=$(awk -v kw="Timestamp:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIE_COMMIT_HASH_FILE")
-      echo "Timestamp: $TIMESTAMP"
-      python3 -m pip install mlir_aie==$MLIR_AIE_VERSION.$TIMESTAMP+$SHORT_MLIR_AIE_COMMIT_HASH.no.rtti -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti/
-      # Install mlir-air
+      # The mlir-air wheel pins the matching mlir-aie commit and requires
+      # llvm-aie via the [aie] extra, so a single pip install pulls the whole
+      # stack with a guaranteed-compatible mlir-aie.
       MLIR_AIR_HASH_FILE=utils/mlir-air-hash.txt
       MLIR_AIR_COMMIT_HASH=$(awk -v kw="Commit:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIR_HASH_FILE")
       SHORT_MLIR_AIR_COMMIT_HASH="${MLIR_AIR_COMMIT_HASH:0:7}"
@@ -61,10 +53,12 @@ jobs:
       echo "mlir-air version: $MLIR_AIR_VERSION"
       MLIR_AIR_TIMESTAMP=$(awk -v kw="Timestamp:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIR_HASH_FILE")
       echo "mlir-air timestamp: $MLIR_AIR_TIMESTAMP"
-      python3 -m pip install mlir_air==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHORT_MLIR_AIR_COMMIT_HASH.no.rtti -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
-      # Install llvm-aie (latest nightly)
-      python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+      python3 -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHORT_MLIR_AIR_COMMIT_HASH.no.rtti" \
+          -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
+          -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti \
+          -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
       python3 -m pip show llvm-aie
+      python3 -m pip show mlir_aie
       # Set environmental variable "MLIR_AIE_INSTALL_DIR"
       MLIR_AIE_INSTALL_DIR_STR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
       echo "MLIR_AIE_INSTALL_DIR=$MLIR_AIE_INSTALL_DIR_STR" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This will automatically install all required dependencies:
 - llvm-aie
 - mlir-air
 
-The versions of mlir-aie and mlir-air are managed in `utils/mlir-aie-hash.txt` and `utils/mlir-air-hash.txt`. llvm-aie uses the latest nightly release.
+The mlir-air version is pinned in `utils/mlir-air-hash.txt`. The matching mlir-aie commit is pinned by the mlir-air wheel's `[aie]` extra, so it's resolved transitively. llvm-aie uses the latest nightly release.
 
 #### Option 3: Build from Source (Using Cmake)
 

--- a/setup.py
+++ b/setup.py
@@ -307,20 +307,15 @@ def _make_version_spec(pkg_name, version, timestamp, short_commit, suffix=""):
 
 
 def get_install_requires():
-    """Build install_requires list from hash files."""
-    mlir_aie_hash_file = BASE_DIR / "utils" / "mlir-aie-hash.txt"
+    """Build install_requires list from hash files.
+
+    Only mlir-air is pinned here. The mlir-air wheel exposes an [aie] extra
+    that pins the matching mlir-aie commit and requires llvm-aie, so we get a
+    guaranteed-compatible mlir-aie transitively without having to pin it
+    ourselves.
+    """
     mlir_air_hash_file = BASE_DIR / "utils" / "mlir-air-hash.txt"
 
-    # Parse mlir-aie version
-    mlir_aie_version = parse_hash_file(mlir_aie_hash_file, "Version")
-    mlir_aie_timestamp = parse_hash_file(mlir_aie_hash_file, "Timestamp")
-    mlir_aie_commit = parse_hash_file(mlir_aie_hash_file, "Commit")
-    mlir_aie_short_commit = mlir_aie_commit[:7]
-    mlir_aie_full_version = (
-        f"{mlir_aie_version}.{mlir_aie_timestamp}+{mlir_aie_short_commit}.no.rtti"
-    )
-
-    # Parse mlir-air version
     mlir_air_version = parse_hash_file(mlir_air_hash_file, "Version")
     mlir_air_timestamp = parse_hash_file(mlir_air_hash_file, "Timestamp")
     mlir_air_commit = parse_hash_file(mlir_air_hash_file, "Commit")
@@ -330,9 +325,7 @@ def get_install_requires():
     )
 
     return [
-        f"mlir-aie=={mlir_aie_full_version}",
-        "llvm-aie",
-        f"mlir-air=={mlir_air_full_version}",
+        f"mlir-air[aie]=={mlir_air_full_version}",
     ]
 
 

--- a/utils/env_setup.ps1
+++ b/utils/env_setup.ps1
@@ -21,49 +21,13 @@ Write-Host "Installing triton-windows..."
 python -m pip install triton-windows
 
 # =============================================================================
-# Install mlir-aie
+# Install mlir-air with [aie] extra
 # =============================================================================
+# The mlir-air wheel pins the matching mlir-aie commit and requires llvm-aie,
+# so a single pip install resolves the whole MLIR-AIE/AIR/LLVM-AIE stack with
+# a guaranteed-compatible mlir-aie.
 
-if (-not $env:MLIR_AIE_INSTALL_DIR) {
-    $HashFile = Join-Path $ScriptDir "mlir-aie-hash-windows.txt"
-    $MLIR_AIE_COMMIT = (Select-String -Path $HashFile -Pattern "^Commit:" | ForEach-Object { ($_ -split ":\s+")[1] }).Trim()
-    $SHORT_COMMIT = $MLIR_AIE_COMMIT.Substring(0, 7)
-    $MLIR_AIE_VERSION = (Select-String -Path $HashFile -Pattern "^Version:" | ForEach-Object { ($_ -split ":\s+")[1] }).Trim()
-    $TIMESTAMP = (Select-String -Path $HashFile -Pattern "^Timestamp:" | ForEach-Object { ($_ -split ":\s+")[1] }).Trim()
-
-    Write-Host "Using mlir-aie hash: $SHORT_COMMIT"
-    Write-Host "Version: $MLIR_AIE_VERSION"
-    Write-Host "Timestamp: $TIMESTAMP"
-
-    python -m pip install "mlir_aie==$MLIR_AIE_VERSION.$TIMESTAMP+$SHORT_COMMIT.no.rtti" -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti
-
-    $MLIR_AIE_INSTALL_DIR = (python -c "import importlib.util; spec = importlib.util.find_spec('mlir_aie'); print(spec.submodule_search_locations[0])") 
-    $env:MLIR_AIE_INSTALL_DIR = $MLIR_AIE_INSTALL_DIR
-}
-
-$env:PATH = "$env:MLIR_AIE_INSTALL_DIR\bin;$env:PATH"
-$env:PYTHONPATH = "$env:MLIR_AIE_INSTALL_DIR\python;$env:PYTHONPATH"
-
-# =============================================================================
-# Install llvm-aie
-# =============================================================================
-
-$HashFile = Join-Path $ScriptDir "llvm-aie-hash-windows.txt"
-$LLVM_AIE_COMMIT = (Select-String -Path $HashFile -Pattern "^Commit:" | ForEach-Object { ($_ -split ":\s+")[1] }).Trim()
-$LLVM_AIE_VERSION = (Select-String -Path $HashFile -Pattern "^Version:" | ForEach-Object { ($_ -split ":\s+")[1] }).Trim()
-$LLVM_AIE_TIMESTAMP = (Select-String -Path $HashFile -Pattern "^Timestamp:" | ForEach-Object { ($_ -split ":\s+")[1] }).Trim()
-
-Write-Host "Using llvm-aie hash: $LLVM_AIE_COMMIT"
-Write-Host "llvm-aie version: $LLVM_AIE_VERSION"
-Write-Host "llvm-aie timestamp: $LLVM_AIE_TIMESTAMP"
-
-python -m pip install "llvm_aie==$LLVM_AIE_VERSION.$LLVM_AIE_TIMESTAMP+$LLVM_AIE_COMMIT" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-
-# =============================================================================
-# Install mlir-air
-# =============================================================================
-
-$HashFile = Join-Path $ScriptDir "mlir-air-hash-windows.txt"
+$HashFile = Join-Path $ScriptDir "mlir-air-hash.txt"
 $MLIR_AIR_COMMIT = (Select-String -Path $HashFile -Pattern "^Commit:" | ForEach-Object { ($_ -split ":\s+")[1] }).Trim()
 $SHORT_AIR_COMMIT = $MLIR_AIR_COMMIT.Substring(0, 7)
 $MLIR_AIR_VERSION = (Select-String -Path $HashFile -Pattern "^Version:" | ForEach-Object { ($_ -split ":\s+")[1] }).Trim()
@@ -73,7 +37,18 @@ Write-Host "Using mlir-air hash: $SHORT_AIR_COMMIT"
 Write-Host "mlir-air version: $MLIR_AIR_VERSION"
 Write-Host "mlir-air timestamp: $MLIR_AIR_TIMESTAMP"
 
-python -m pip install "mlir_air==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHORT_AIR_COMMIT.no.rtti" -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
+python -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHORT_AIR_COMMIT.no.rtti" `
+    -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti `
+    -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti `
+    -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+
+if (-not $env:MLIR_AIE_INSTALL_DIR) {
+    $MLIR_AIE_INSTALL_DIR = (python -c "import importlib.util; spec = importlib.util.find_spec('mlir_aie'); print(spec.submodule_search_locations[0])")
+    $env:MLIR_AIE_INSTALL_DIR = $MLIR_AIE_INSTALL_DIR
+}
+
+$env:PATH = "$env:MLIR_AIE_INSTALL_DIR\bin;$env:PATH"
+$env:PYTHONPATH = "$env:MLIR_AIE_INSTALL_DIR\python;$env:PYTHONPATH"
 
 # =============================================================================
 # Install triton-xdna (copies backend into triton-windows)

--- a/utils/env_setup.ps1
+++ b/utils/env_setup.ps1
@@ -42,6 +42,12 @@ python -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHO
     -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti `
     -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
+# The [aie] extra requires llvm-aie without a version pin. To track the
+# nightly wheel, force-upgrade llvm-aie explicitly so an existing installation
+# doesn't silently satisfy the unpinned requirement.
+python -m pip install --upgrade llvm-aie `
+    -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+
 if (-not $env:MLIR_AIE_INSTALL_DIR) {
     $MLIR_AIE_INSTALL_DIR = (python -c "import importlib.util; spec = importlib.util.find_spec('mlir_aie'); print(spec.submodule_search_locations[0])")
     $env:MLIR_AIE_INSTALL_DIR = $MLIR_AIE_INSTALL_DIR

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -8,7 +8,7 @@ SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 # Install mlir-air with the [aie] extra. The mlir-air wheel pins the matching
 # mlir-aie commit and requires llvm-aie, so a single pip install resolves the
 # whole MLIR-AIE/AIR/LLVM-AIE stack with a guaranteed-compatible mlir-aie.
-MLIR_AIR_HASH_FILE="$(dirname ${SCRIPT_PATH})/mlir-air-hash.txt"
+MLIR_AIR_HASH_FILE="$(dirname "${SCRIPT_PATH}")/mlir-air-hash.txt"
 MLIR_AIR_COMMIT_HASH=$(awk -v kw="Commit:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIR_HASH_FILE")
 SHORT_MLIR_AIR_COMMIT_HASH="${MLIR_AIR_COMMIT_HASH:0:7}"
 echo "Using mlir-air hash: $SHORT_MLIR_AIR_COMMIT_HASH"
@@ -21,10 +21,16 @@ python3 -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SH
     -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti \
     -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
-if [[ $MLIR_AIE_INSTALL_DIR == "" ]]; then
+# The [aie] extra requires llvm-aie without a version pin. To track the
+# nightly wheel (matching the prior env_setup.sh behavior), force-upgrade
+# llvm-aie explicitly so an existing installation doesn't silently satisfy
+# the unpinned requirement.
+python3 -m pip install --upgrade llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+
+if [[ "$MLIR_AIE_INSTALL_DIR" == "" ]]; then
     export MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
 fi
 
-export PATH=${MLIR_AIE_INSTALL_DIR}/bin:${PATH}
-export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
-export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
+export PATH="${MLIR_AIE_INSTALL_DIR}/bin:${PATH}"
+export PYTHONPATH="${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}"
+export LD_LIBRARY_PATH="${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}"

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -5,29 +5,9 @@
 
 SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 
-if [[ $MLIR_AIE_INSTALL_DIR == "" ]]; then
-    SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
-    MLIR_AIE_COMMIT_HASH_FILE="$(dirname ${SCRIPT_PATH})/mlir-aie-hash.txt"
-    # Install mlir-aie
-    MLIR_AIE_COMMIT_HASH=$(awk -v kw="Commit:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIE_COMMIT_HASH_FILE")
-    SHORT_MLIR_AIE_COMMIT_HASH="${MLIR_AIE_COMMIT_HASH:0:7}"
-    echo "Using mlir-aie hash: $SHORT_MLIR_AIE_COMMIT_HASH"
-    MLIR_AIE_VERSION=$(awk -v kw="Version:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIE_COMMIT_HASH_FILE")
-    echo "Version: $MLIR_AIE_VERSION"
-    TIMESTAMP=$(awk -v kw="Timestamp:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIE_COMMIT_HASH_FILE")
-    echo "Timestamp: $TIMESTAMP"
-    python3 -m pip install mlir_aie==$MLIR_AIE_VERSION.$TIMESTAMP+$SHORT_MLIR_AIE_COMMIT_HASH.no.rtti -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti
-    export MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
-fi
-
-export PATH=${MLIR_AIE_INSTALL_DIR}/bin:${PATH} 
-export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
-export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
-
-# Install llvm-aie (latest nightly)
-python3 -m pip install --upgrade llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-
-# Install mlir-air
+# Install mlir-air with the [aie] extra. The mlir-air wheel pins the matching
+# mlir-aie commit and requires llvm-aie, so a single pip install resolves the
+# whole MLIR-AIE/AIR/LLVM-AIE stack with a guaranteed-compatible mlir-aie.
 MLIR_AIR_HASH_FILE="$(dirname ${SCRIPT_PATH})/mlir-air-hash.txt"
 MLIR_AIR_COMMIT_HASH=$(awk -v kw="Commit:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIR_HASH_FILE")
 SHORT_MLIR_AIR_COMMIT_HASH="${MLIR_AIR_COMMIT_HASH:0:7}"
@@ -36,4 +16,15 @@ MLIR_AIR_VERSION=$(awk -v kw="Version:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i ==
 echo "mlir-air version: $MLIR_AIR_VERSION"
 MLIR_AIR_TIMESTAMP=$(awk -v kw="Timestamp:" '$0 ~ kw {for (i=1; i<NF; i++) if ($i == kw) print $(i+1)}' "$MLIR_AIR_HASH_FILE")
 echo "mlir-air timestamp: $MLIR_AIR_TIMESTAMP"
-python3 -m pip install mlir_air==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHORT_MLIR_AIR_COMMIT_HASH.no.rtti -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
+python3 -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHORT_MLIR_AIR_COMMIT_HASH.no.rtti" \
+    -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
+    -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti \
+    -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+
+if [[ $MLIR_AIE_INSTALL_DIR == "" ]]; then
+    export MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
+fi
+
+export PATH=${MLIR_AIE_INSTALL_DIR}/bin:${PATH}
+export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
+export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}

--- a/utils/mlir-aie-hash.txt
+++ b/utils/mlir-aie-hash.txt
@@ -1,3 +1,0 @@
-Commit: 5b5376b
-Timestamp: 2026040821
-Version: 0.0.1

--- a/utils/mlir-air-hash.txt
+++ b/utils/mlir-air-hash.txt
@@ -1,3 +1,3 @@
-Commit: c8ec089
-Timestamp: 2026042305
+Commit: dfa6d08
+Timestamp: 2026050805
 Version: 0.0.1


### PR DESCRIPTION
## Summary

- Bump `utils/mlir-air-hash.txt` to `dfa6d08` / `2026050805` (latest mlir-air no-rtti wheel).
- Delete `utils/mlir-aie-hash.txt`. The new mlir-air wheel exposes a `[aie]` extra that pins the matching `mlir_aie` commit and requires `llvm-aie`, so we no longer need to maintain a separate aie hash file by hand.
- Collapse the two-step `pip install mlir_aie==... && pip install mlir_air==...` flow in `env_setup.sh`, `env_setup.ps1`, `setup.py`'s `get_install_requires`, and `.github/workflows/build.yml` into a single `pip install "mlir_air[aie]==<ver>"`.

The new air wheel's METADATA contains:
```
Provides-Extra: aie
Requires-Dist: mlir_aie==0.0.1.2026050723+52dd9bc.no.rtti; extra == "aie"
Requires-Dist: llvm-aie; extra == "aie"
```

So `mlir-air[aie]==0.0.1.2026050805+dfa6d08.no.rtti` resolves the whole MLIR-AIE/AIR/LLVM-AIE stack with a guaranteed-compatible mlir-aie. The mlir-aie commit can never drift out of sync with mlir-air anymore.

The `.ps1` script also previously referenced `mlir-aie-hash-windows.txt`, `llvm-aie-hash-windows.txt`, and `mlir-air-hash-windows.txt` -- none of which exist in `utils/`. The new single-install path uses the existing `mlir-air-hash.txt` so it actually works.

## Test plan

- [x] `pip install "mlir_air[aie]==0.0.1.2026050805+dfa6d08.no.rtti"` in a fresh venv resolved mlir-air `dfa6d08`, the air-pinned mlir-aie `52dd9bc`, and llvm-aie `21.0.0.2026050801+783f8625` in one shot.
- [x] `setup.py:get_install_requires()` returns `['mlir-air[aie]==0.0.1.2026050805+dfa6d08.no.rtti']`.
- [ ] CI build (`build.yml`) passes on the bumped versions.
- [ ] NPU hardware tests (`small.yml`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)