### PR TITLE
Fix weighted_rms_norm bf16 reduce precision bug via layernorm-style transform refactor

### DIFF
--- a/examples/weighted_rms_norm/transform_aie2p.mlir
+++ b/examples/weighted_rms_norm/transform_aie2p.mlir
@@ -1,87 +1,162 @@
-// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
-// SPDX-License-Identifier: MIT
-
-// Weighted RMS Norm transform for AIE2P.
-// y = x * rsqrt(mean(x^2) + eps) * w
-//
-// No fuse_multi_op_linalg (creates L2 refs). CSE merges duplicate X
-// extract_slices so linalg_promote shares one L1 X buffer across ops.
+// Weighted RMS Norm transform for AIE2P, following mlir-air xrt 43_triton_layernorm/transform_aie2p.mlir.
+// Chain (after fuse_elementwise + transpose_reduce): generic_sq -> reduce -> output_generic (consumes W).
+// Hybrid: bufferize_to_allocation for fills/generics/reduce; linalg_promote for W only (post-bufferize).
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+
+    // PHASE 1: canonicalize + fold unit extent
     %func0 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.apply_patterns to %func0 { transform.apply_patterns.canonicalization
-        transform.apply_patterns.linalg.fold_unit_extent_dims_via_reshapes } : !transform.any_op
+    transform.apply_patterns to %func0 {
+        transform.apply_patterns.linalg.tiling_canonicalization
+        transform.apply_patterns.scf.for_loop_canonicalization
+        transform.apply_patterns.canonicalization
+        transform.apply_patterns.linalg.fold_unit_extent_dims_via_reshapes
+    } : !transform.any_op
     transform.apply_cse to %func0 : !transform.any_op
+
+    // PHASE 2: fuse elementwise + transpose reduce + canonicalize
+    %func1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %fused_func = transform.air.fuse_elementwise_linalg %func1 : (!transform.any_op) -> !transform.any_op
     %reduces = transform.structured.match ops{["linalg.reduce"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %tr = transform.air.transpose_reduce %reduces : (!transform.any_op) -> !transform.any_op
-    %func1a = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.apply_patterns to %func1a { transform.apply_patterns.canonicalization } : !transform.any_op
-    transform.apply_cse to %func1a : !transform.any_op
-    %func1 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %f = transform.air.fuse_elementwise_linalg %func1 : (!transform.any_op) -> !transform.any_op
-    %fa = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.apply_patterns to %fa { transform.apply_patterns.canonicalization } : !transform.any_op
-    transform.apply_cse to %fa : !transform.any_op
 
-    %ag = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %sq, %out = transform.split_handle %ag : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-    %reduce = transform.structured.match ops{["linalg.reduce"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %fused_func {
+        transform.apply_patterns.linalg.tiling_canonicalization
+        transform.apply_patterns.scf.for_loop_canonicalization
+        transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    transform.apply_cse to %fused_func : !transform.any_op
+
+    // Data-flow navigation. Chain: generic_sq -> reduce -> output_generic (consumes W)
+    %r = transform.structured.match ops{["linalg.reduce"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %generic_sq = transform.get_producer_of_operand %r[0] : (!transform.any_op) -> !transform.any_op
+    %materialize = transform.structured.match ops{["bufferization.materialize_in_destination"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %output_generic = transform.get_producer_of_operand %materialize[0] : (!transform.any_op) -> !transform.any_op
     %fill = transform.structured.match ops{["linalg.fill"]} in %arg1 : (!transform.any_op) -> !transform.any_op
 
-    %ob, %nb = transform.structured.bufferize_to_allocation %out {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
-    %t, %fl = transform.structured.tile_using_forall %out tile_sizes [1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
-    %f1, %fl1 = transform.structured.fuse_into_containing_op %reduce into %fl : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
-    %f2, %fl2 = transform.structured.fuse_into_containing_op %sq into %fl1 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
-    %f3, %fl3 = transform.structured.fuse_into_containing_op %fill into %fl2 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    // PHASE 3: L2 alloc for output, tile, fuse backward
+    %ob, %on = transform.structured.bufferize_to_allocation %output_generic
+        {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    %tiled_output, %forall = transform.structured.tile_using_forall %output_generic tile_sizes [1]
+        : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    // Fill dest → L1
-    %fills3 = transform.structured.match ops{["linalg.fill"]} in %fl3 : (!transform.any_op) -> !transform.any_op
-    %fill_buf, %fill_new = transform.structured.bufferize_to_allocation %fills3
+    %fr, %fl_r = transform.structured.fuse_into_containing_op %r into %forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fg, %fl_g = transform.structured.fuse_into_containing_op %generic_sq into %fl_r : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %ff, %fl_f = transform.structured.fuse_into_containing_op %fill into %fl_g : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // PHASE 4: canonicalize
+    %func2 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func2 {
+        transform.apply_patterns.linalg.tiling_canonicalization
+        transform.apply_patterns.scf.for_loop_canonicalization
+        transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    transform.apply_cse to %func2 : !transform.any_op
+
+    // PHASE 5: L1 alloc for fills + intermediate ops + X promotion
+    %fills_2 = transform.structured.match ops{["linalg.fill"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %fb, %fn = transform.structured.bufferize_to_allocation %fills_2
         {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
 
-    // CSE to merge duplicate X extract_slices from fuse_into_containing_op.
-    // sq and out both slice from the same X tensor -- CSE merges them so
-    // linalg_promote's promotedValueMap shares one L1 buffer.
-    transform.include @canonicalize_with_cse failures(propagate) (%arg1) : (!transform.any_op) -> ()
+    %generics2 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %tiled_generic1, %tiled_generic2 = transform.split_handle %generics2 : (!transform.any_op<"linalg.generic">) -> (!transform.any_op<"linalg.generic">, !transform.any_op<"linalg.generic">)
+    %reduces2 = transform.structured.match ops{["linalg.reduce"]} in %arg1 : (!transform.any_op) -> !transform.any_op
 
-    // Bufferize
+    // Promote X (input of generic_sq, operand 0) to L1
+    %op0 = transform.get_operand %tiled_generic1[0] : (!transform.any_op) -> !transform.any_value
+    transform.structured.promote_tensor to 2 %op0 : !transform.any_value
+
+    // L1 alloc for intermediate outputs (W stays at function input until post-bufferize linalg_promote)
+    %g1b, %g1n = transform.structured.bufferize_to_allocation %tiled_generic1
+        {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    %rb, %rn = transform.structured.bufferize_to_allocation %reduces2
+        {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    %g2b, %g2n = transform.structured.bufferize_to_allocation %tiled_generic2
+        {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // PHASE 6: canonicalize
+    %func5 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func5 {
+        transform.apply_patterns.linalg.tiling_canonicalization
+        transform.apply_patterns.scf.for_loop_canonicalization
+        transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    transform.apply_cse to %func5 : !transform.any_op
+
+    // PHASE 7: one_shot_bufferize
     transform.include @one_shot_bufferize failures(propagate) (%arg1) : (!transform.any_op) -> ()
-    %f6 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.apply_patterns to %f6 { transform.apply_patterns.canonicalization } : !transform.any_op
-    transform.apply_cse to %f6 : !transform.any_op
-    %lc = transform.structured.match ops{["linalg.copy"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %mc = transform.structured.linalg_copy_to_memref %lc : (!transform.any_op) -> !transform.any_op
-    %fu = transform.air.remove_uninitialized_copy %f6 : (!transform.any_op) -> (!transform.any_op)
-    %fu2 = transform.air.eliminate_cascade_memcpy %fu : (!transform.any_op) -> (!transform.any_op)
 
-    // linalg_promote for ALL operands (X, weight, output) with consistent
-    // memory space attributes. No tensor-domain promotion needed.
-    %forall_op = transform.structured.match ops{["scf.forall"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %gens_f = transform.structured.match ops{["linalg.generic"]} in %forall_op : (!transform.any_op) -> !transform.any_op
-    %reds_f = transform.structured.match ops{["linalg.reduce"]} in %forall_op : (!transform.any_op) -> !transform.any_op
-    %all_linalg_f = transform.merge_handles %reds_f, %gens_f { deduplicate } : !transform.any_op
-    %promoted = transform.air.linalg_promote %all_linalg_f {memory_space = "L1"} : (!transform.any_op) -> !transform.any_op
+    // PHASE 8: canonicalize + remove uninitialized copy
+    %func6 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func6 {
+        transform.apply_patterns.linalg.tiling_canonicalization
+        transform.apply_patterns.scf.for_loop_canonicalization
+        transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    transform.apply_cse to %func6 : !transform.any_op
+    transform.apply_patterns to %func6 {
+        transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    %func_op_updated = transform.air.remove_uninitialized_copy %func6 : (!transform.any_op) -> !transform.any_op
 
-    // No post-promote canonicalization (it hoists allocs out of forall region)
+    // PHASE 8.5: linalg_promote to add L1 staging for W (post-bufferize).
+    // The output_generic now has memref operands ins(X_L1, reduced_L1, W_func_input).
+    // Promote operand 2 (W) only - other operands are already L1.
+    %output_gen_buf = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %sq_buf, %out_buf = transform.split_handle %output_gen_buf : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %w_promoted = transform.air.linalg_promote %out_buf {memory_space = "L1", operands_to_promote = [2]} : (!transform.any_op) -> !transform.any_op
 
-    // Herd + DMA
-    %fh = transform.structured.match ops{["scf.forall"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %pa = transform.loop.forall_to_parallel %fh : (!transform.any_op) -> !transform.any_op
-    %h = transform.air.par_to_herd %pa : (!transform.any_op) -> !transform.any_op
+    // Canonicalize to fold any self-copies linalg_promote may have introduced.
+    %fp = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %fp { transform.apply_patterns.canonicalization } : !transform.any_op
+    transform.apply_cse to %fp : !transform.any_op
 
-    // Override herd-internal allocs to L1
-    %herd_ms = transform.structured.match ops{["air.herd"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %herd_ms_done = transform.air.override_memref_memory_space %herd_ms {memory_space = 2 : i32} : (!transform.any_op) -> !transform.any_op
+    // PHASE 9: generalize remaining linalg.reduce, tile for vectorization, divf-sqrt -> rsqrt
+    %remaining_reduces = transform.structured.match ops{["linalg.reduce"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %generalized = transform.structured.generalize %remaining_reduces : (!transform.any_op) -> !transform.any_op
 
-    %h_fresh = transform.structured.match ops{["air.herd"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %lg = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %inner, %vl:1 = transform.structured.tile_using_for %lg tile_sizes [0, 16] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    // Skip copy_to_dma here -- driver's step 3 runs air-copy-to-dma pass
-    // which handles self-copy elimination (PR #1390).
+    %fou1 = transform.air.convert_divf_sqrt_to_rsqrt %func_op_updated : (!transform.any_op) -> !transform.any_op
 
-    // No post-herd cleanup (canonicalization hoists allocs across regions)
+    // PHASE 10: par_to_herd, copy_to_dma, herd_vectorize, casts
+    %fa = transform.structured.match ops{["scf.forall"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %parallel = transform.loop.forall_to_parallel %fa : (!transform.any_op) -> !transform.any_op
+    %herd = transform.air.par_to_herd %parallel : (!transform.any_op) -> !transform.any_op
 
-    // STOP HERE to check domination
+    %copies_in_herd = transform.structured.match ops{["memref.copy", "linalg.copy"]} in %herd : (!transform.any_op) -> !transform.any_op
+    %dmas = transform.air.copy_to_dma %copies_in_herd : (!transform.any_op) -> !transform.any_op
+
+    %vh = transform.air.herd_vectorize %herd : (!transform.any_op) -> !transform.any_op
+
+    %func4 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func4 {
+        transform.apply_patterns.canonicalization
+        transform.apply_patterns.vector.cast_away_vector_leading_one_dim
+    } : !transform.any_op
+
+    %vh2 = transform.air.broadcast_before_unary %func4 {op_name = "math.rsqrt"} : (!transform.any_op) -> !transform.any_op
+
+    %vector_reductions = transform.structured.match ops{["vector.multi_reduction"]} in %vh2 : (!transform.any_op) -> !transform.any_op
+    %r1 = transform.air.vector_type_cast %vector_reductions {target_element_type = bf16} : (!transform.any_op) -> !transform.any_op
+
+    %vector_muls = transform.structured.match ops{["arith.mulf"]} in %vh2 : (!transform.any_op) -> !transform.any_op
+    %r2 = transform.air.vector_type_cast %vector_muls {target_element_type = bf16} : (!transform.any_op) -> !transform.any_op
+
+    %func7 = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %func7t = transform.air.convert_size1_vector_to_scalar %func7 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func7t {
+        transform.apply_patterns.linalg.tiling_canonicalization
+        transform.apply_patterns.scf.for_loop_canonicalization
+        transform.apply_patterns.canonicalization
+        transform.apply_patterns.vector.reorder_multi_reduction_dims lowering_strategy = "innerreduction"
+        transform.apply_patterns.vector.multi_reduction_flattening lowering_strategy = "innerreduction"
+        transform.apply_patterns.vector.multi_reduction_unrolling lowering_strategy = "innerreduction"
+    } : !transform.any_op
+    transform.apply_cse to %func7t : !transform.any_op
+
     transform.yield
   }
 }

--- a/examples/weighted_rms_norm/transform_aie2p.mlir
+++ b/examples/weighted_rms_norm/transform_aie2p.mlir
@@ -1,3 +1,6 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
 // Weighted RMS Norm transform for AIE2P, following mlir-air xrt 43_triton_layernorm/transform_aie2p.mlir.
 // Chain (after fuse_elementwise + transpose_reduce): generic_sq -> reduce -> output_generic (consumes W).
 // Hybrid: bufferize_to_allocation for fills/generics/reduce; linalg_promote for W only (post-bufferize).
@@ -103,8 +106,11 @@ module attributes {transform.with_named_sequence} {
     // PHASE 8.5: linalg_promote to add L1 staging for W (post-bufferize).
     // The output_generic now has memref operands ins(X_L1, reduced_L1, W_func_input).
     // Promote operand 2 (W) only - other operands are already L1.
-    %output_gen_buf = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %sq_buf, %out_buf = transform.split_handle %output_gen_buf : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    // Restrict match to the forall body so unrelated post-bufferize generics
+    // (e.g. memcpy-like) can't poison the split.
+    %forall_buf = transform.structured.match ops{["scf.forall"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %generics_in_forall = transform.structured.match ops{["linalg.generic"]} in %forall_buf : (!transform.any_op) -> !transform.any_op
+    %sq_buf, %out_buf = transform.split_handle %generics_in_forall : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     %w_promoted = transform.air.linalg_promote %out_buf {memory_space = "L1", operands_to_promote = [2]} : (!transform.any_op) -> !transform.any_op
 
     // Canonicalize to fold any self-copies linalg_promote may have introduced.


### PR DESCRIPTION
## Summary

Fixes a systematic precision bug in [examples/weighted_rms_norm/transform_aie2p.mlir](examples/weighted_rms_norm/transform_aie2p.mlir) on aie2p where the kernel's \`sum_sq\` was ~20% too low for typical inputs, producing \`rstd\` ~12% too high. User-facing tests caught this intermittently as 1-element outliers exceeding tolerance (≈3% failure rate on random data; with seed=0, 99/16384 elements drift).

## Root cause

The previous script left the bf16 \`linalg.reduce\` over 256 elements untiled. \`aircc\` then lowered it as a sequential **scalar bf16 accumulator** that systematically underestimates the sum. Confirmed by directly dumping kernel-computed \`sum_sq\` on seed=0 (row 32: ref=254.13, kernel=200.00, **−21.3%**), and by comparing against \`rms_norm\`'s transform script which DOES tile the reduce — same kernel structure, drift drops to ~2.4%.

## Fix

Refactor follows the mlir-air xrt \`43_triton_layernorm/transform_aie2p.mlir\` prototype:

- **Phases 1–8:** per-op \`bufferize_to_allocation {memory_space=2}\` for fills, intermediate generic, reduce, output generic; \`promote_tensor to 2\` for X. Eliminates the redundant L1→L1 copy chain that \`linalg_promote\` produced for X.
- **Phase 8.5 (kernel-specific):** post-bufferize \`transform.air.linalg_promote {operands_to_promote=[2]}\` on the output generic to stage W (extra input vs layernorm) into a per-core L1 buffer. Layernorm's prototype has no W operand, so this hybrid step extends the pattern.
- **Phase 9:** \`generalize\` the reduce, \`tile_using_for [0,16]\`, \`convert_divf_sqrt_to_rsqrt\`.
- **Phase 10:** \`par_to_herd → copy_to_dma → herd_vectorize\` — the reduce now lowers to \`vector.reduction <add>\`, which is precision-correct.

## Verification on local NPU2 (Strix)

| Test | Before | After |
|---|---|---|
| seed=0 worst element | abs diff **1.125**, 99/16384 bad | abs diff **0.125**, 0 bad |
| 30 random runs | ~3% failure rate | 0/30 fail |
| 20 deterministic seeds | many would fail | 0 bad seeds, worst max_abs=0.1875 |
| \`scripts/run_tests.py --device aie2p\` | weighted_rms_norm fails ~3% | **17/18 pass** (only pre-existing matvec) |

## Out of scope

The mlir-air reference design also DMAs W **once** before the row loop. This refactor still DMAs W per-row (one of three gaps documented during investigation; correctness gap is fixed, this is an efficiency gap). Hoisting the W DMA needs a different staging mechanism and is left as future work.

## Test plan

- [x] Standalone \`python examples/weighted_rms_norm/weighted_rms_norm.py\` on aie2p
- [x] 30 random-input runs with default unseeded \`torch.randn\`
- [x] 20 deterministic seeds with \`torch.manual_seed\`
- [x] \`scripts/run_tests.py --device aie2p\` (17/18 pass; matvec unrelated)
- [ ] Verify on Windows aie2p (host-OS-independent fix; expected to pass)
- [ ] aie2 path unaffected (no \`transform_aie2.mlir\` exists for this kernel; aie2p-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)