### PR TITLE
Default to elf format for npu2 on Windows

### DIFF
--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -478,10 +478,7 @@ def _get_output_format():
                 "npu_config.output_format to 'xclbin' or None."
             )
         return configured_format
-    # Auto-detect: xclbin on Windows (ELF flow has stoul bug in NPU driver),
-    # ELF for npu2 on Linux, xclbin for npu1 everywhere.
-    if IS_WINDOWS:
-        return "xclbin"
+    # Auto-detect: ELF for npu2, xclbin for npu1.
     return "elf" if npu_version == "npu2" else "xclbin"
 
 


### PR DESCRIPTION
Tested on Win11 win NPU `Driver version: 32.0.20101.3760` and `Driver date: 4/4/2026`.
```
(.venv) D:\Triton-XDNA>scripts\run_tests --device aie2p
Starting example test run...
Examples dir: D:\Triton-XDNA\examples
Target device: aie2p
Transform file: transform_aie2p.mlir
--------------------------------------------------
📁 Example: autotune-matmul
   ⏭️  SKIP: transform_aie2p.mlir not found for device aie2p

📁 Example: average_pool
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: average_pool.py
   ✅ PASS: average_pool.py

📁 Example: axpy
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: axpy.py
   ✅ PASS: axpy.py

📁 Example: gelu
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: gelu.py
   ✅ PASS: gelu.py

📁 Example: leaky_relu
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: leaky_relu.py
   ✅ PASS: leaky_relu.py

📁 Example: matmul_bf16_m64_n64_k64
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: matmul_bf16_m64_n64_k64.py
   ✅ PASS: matmul_bf16_m64_n64_k64.py

📁 Example: matmul_f32_m64_n32_k16_padded_atransposed
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: matmul_f32_m64_n32_k16_padded_atransposed.py
   ✅ PASS: matmul_f32_m64_n32_k16_padded_atransposed.py

📁 Example: matmul_i8_m128_n64_k64
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: matmul_i8_m128_n64_k64.py
   ✅ PASS: matmul_i8_m128_n64_k64.py

📁 Example: matmul_i8_m64_n64_k64
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: matmul_i8_m64_n64_k64.py
   ✅ PASS: matmul_i8_m64_n64_k64.py

📁 Example: relu
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: relu.py
   ✅ PASS: relu.py

📁 Example: rms_norm
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: rms_norm.py
   ✅ PASS: rms_norm.py

📁 Example: sigmoid
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: sigmoid.py
   ✅ PASS: sigmoid.py

📁 Example: silu
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: silu.py
   ✅ PASS: silu.py

📁 Example: swiglu
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: swiglu.py
   ✅ PASS: swiglu.py

📁 Example: test_layernorm
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: test_layernorm.py
   ✅ PASS: test_layernorm.py

📁 Example: test_softmax
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: test_softmax.py
   ✅ PASS: test_softmax.py

📁 Example: vec-add
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: vec-add.py
   ✅ PASS: vec-add.py

📁 Example: weighted_rms_norm
   transform_aie2p.mlir detected; will set AIR_TRANSFORM_TILING_SCRIPT
   🔄 Running: weighted_rms_norm.py
   ✅ PASS: weighted_rms_norm.py

--------------------------------------------------
Test Results:
  ✅ Passed:  17
  ❌ Failed:  0
  ⏰ Timeouts: 0
  ⏭️  Skipped: 1
  📊 Total:   17
🎉 All tests passed!
```