### PR TITLE
Fix elementwise herd width: tile by num_threads, not fixed tile size

### DIFF
--- a/amd_triton_npu/backend/transform_library/elementwise.mlir
+++ b/amd_triton_npu/backend/transform_library/elementwise.mlir
@@ -26,8 +26,14 @@ transform.named_sequence @fuse_elementwise_and_canonicalize(
 // With tile_sizes the width was ceildiv(block, tile): a single trip when the
 // block fits one tile (the forall is then folded away, leaving no herd) and
 // wider than the target's column count for large blocks (placement fails). A
-// fixed thread count avoids both. NOTE: the count below is sized for the npu1
-// 4-column array; targets with more columns (AIE2P) may want a larger value.
+// fixed thread count avoids both.
+//
+// The count is intentionally hardcoded to 4 for the npu1 4-column array. This
+// sequence is also included by AIE2P (npu2) elementwise scripts, where 4 caps
+// the herd at 4 of the 8 available columns -- correct, but it under-utilizes
+// the array for large blocks. Making the count target-aware (a per-target
+// sequence, or a driver-injected parameter) is left as a follow-up; 4 is kept
+// for now because it is the value validated on npu1 hardware.
 transform.named_sequence @flatten_tile_forall(
     %module: !transform.any_op {transform.readonly}) {
   %op = transform.structured.match ops{["linalg.generic"]} in %module
@@ -41,6 +47,7 @@ transform.named_sequence @flatten_tile_forall(
   %op_1 = transform.structured.match ops{["linalg.generic"]} in %module
       : (!transform.any_op) -> !transform.any_op
   %tiled_op_1, %forall_op_1 =
+      // 4 = npu1 column count (hardcoded; see note above for AIE2P/npu2).
       transform.structured.tile_using_forall %op_1 num_threads [4]
       : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
   transform.yield

--- a/amd_triton_npu/backend/transform_library/elementwise.mlir
+++ b/amd_triton_npu/backend/transform_library/elementwise.mlir
@@ -21,7 +21,10 @@ transform.named_sequence @fuse_elementwise_and_canonicalize(
   transform.yield
 }
 
-// Flatten to 1D, allocate result in L2, tile forall [256] for multi-core.
+// Flatten to 1D, allocate result in L2, split across a fixed number of cores.
+// num_threads (not tile_sizes) fixes the herd width regardless of block size:
+// tile_sizes [256] made width = BLOCK/256, which folds to no herd when
+// BLOCK <= 256 and overflows the 4-column array when BLOCK >= 2048.
 transform.named_sequence @flatten_tile_forall(
     %module: !transform.any_op {transform.readonly}) {
   %op = transform.structured.match ops{["linalg.generic"]} in %module
@@ -35,7 +38,7 @@ transform.named_sequence @flatten_tile_forall(
   %op_1 = transform.structured.match ops{["linalg.generic"]} in %module
       : (!transform.any_op) -> !transform.any_op
   %tiled_op_1, %forall_op_1 =
-      transform.structured.tile_using_forall %op_1 tile_sizes [256]
+      transform.structured.tile_using_forall %op_1 num_threads [4]
       : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
   transform.yield
 }

--- a/amd_triton_npu/backend/transform_library/elementwise.mlir
+++ b/amd_triton_npu/backend/transform_library/elementwise.mlir
@@ -22,9 +22,12 @@ transform.named_sequence @fuse_elementwise_and_canonicalize(
 }
 
 // Flatten to 1D, allocate result in L2, split across a fixed number of cores.
-// num_threads (not tile_sizes) fixes the herd width regardless of block size:
-// tile_sizes [256] made width = BLOCK/256, which folds to no herd when
-// BLOCK <= 256 and overflows the 4-column array when BLOCK >= 2048.
+// num_threads (not tile_sizes) keeps the herd width independent of block size.
+// With tile_sizes the width was ceildiv(block, tile): a single trip when the
+// block fits one tile (the forall is then folded away, leaving no herd) and
+// wider than the target's column count for large blocks (placement fails). A
+// fixed thread count avoids both. NOTE: the count below is sized for the npu1
+// 4-column array; targets with more columns (AIE2P) may want a larger value.
 transform.named_sequence @flatten_tile_forall(
     %module: !transform.any_op {transform.readonly}) {
   %op = transform.structured.match ops{["linalg.generic"]} in %module


### PR DESCRIPTION
## Summary

`@flatten_tile_forall` (shared by all elementwise examples) tiled the flattened op with `tile_sizes [256]`, making the herd width = `BLOCK_SIZE_N / 256`. That width is unbounded in both directions and breaks AIR→AIE lowering at the edges. This PR switches the forall tiling to `num_threads [4]`, fixing the herd width at ≤ 4 columns for any block size.

### Root cause (what `tile_sizes [256]` did wrong)
- **width 1** (`BLOCK ≤ 256`): the single-trip `scf.forall` is canonicalized away before herd mapping, so `par_to_herd` matches nothing — it emits `"expected a single payload op"` which is **silently non-fatal** — and the compute is never placed in a herd. `aircc` then fails downstream in `air-dma-to-channel` with `"operand does not dominate this use"`.
- **width ≥ 8** (`BLOCK ≥ 2048`): the herd is wider than the 4-column array → `"No valid placement found"`.

`num_threads [4]` always produces ≤ 4 tiles, so the forall never folds to zero and never overflows the array.

## Validation

Tested on **npu1 hardware**, vec-add, **maskless**, triton cache cleared before every config:

| BLOCK_SIZE_N | before (`tile_sizes [256]`) | after (`num_threads [4]`) |
|---|---|---|
| ≤ 64 | FAIL | MISMATCH (see limitations) |
| 128 – 32768 (pow2) | only 512, 1024 PASS | **all PASS** |
| ≥ 65536 | FAIL | OOM (L2 capacity) |

Multi-block (e.g. `N=8192, BLOCK=1024`) and ragged tails (e.g. `N=1500, BLOCK=512`) PASS. The canonical `examples/vec-add/vec-add.py` sweep (BLOCK=1024, N=1024…32768) still passes — no regression.

## Shape coverage after this change

**Supported ⟺ `BLOCK_SIZE_N` is a power of 2 AND `128 ≤ BLOCK_SIZE_N ≤ 32768`.**
- **N (data size) is unrestricted** — `grid = cdiv(N, BLOCK)` scales it and the ragged last block is handled by the launch-level size clamp. e.g. `N=8` works fine with `BLOCK=128` or `1024`; only `BLOCK` matters.
- Lower bound `BLOCK ≥ 128`: per-core tile = `BLOCK/4` must be ≥ 2 vectors (≥ 32 for vector-16).
- Upper bound `BLOCK ≤ 32768`: L2/memtile capacity (binary op = 3 bf16 buffers); `BLOCK=65536` OOMs.

## Known limitations

1. **Masks are not supported.** Any kernel using `tl.load/store(..., mask=...)` aborts `aircc` with SIGABRT, regardless of size — even a statically all-true mask. This is an independent backend bug, **not addressed here**. (Note: ragged-tail bounds safety is already provided by AIR's launch-level size clamp, so maskless kernels with a partial last block still compute correct results.)
2. **`BLOCK_SIZE_N < 128` produces wrong results** (compiles, MISMATCH). At `BLOCK=64` each core's tile is a single 16-lane vector, so the vectorize `tile_using_for [16]` becomes single-trip, gets folded, and corrupts — the same single-trip pathology as the herd forall, one level down. Lowering this floor needs an adaptive vector width / scalar fallback in `@vectorize_generics_at_*`.
3. **`num_threads [4]` is hardcoded to npu1's 4 columns.** On npu2/AIE2P (more columns) this is correct but under-utilizes the array (caps at 4 cores). A follow-up should make the thread count target-aware (the textual `transform.include` mechanism can't pass params, so this likely needs the driver to inject it).
4. **Scope of validation:** only **vec-add on npu1, maskless** was run on hardware. `@flatten_tile_forall` is shared by relu, silu, gelu, swiglu, leaky_relu (aie2 and aie2p). The change is structurally identical for those, but they have **not** been validated here — reviewers should confirm before relying on them, especially on npu2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)