### PR TITLE
Add AIE2P (npu2) elementwise herd width: 8 threads for 8-column array

### DIFF
--- a/amd_triton_npu/backend/transform_library/elementwise.mlir
+++ b/amd_triton_npu/backend/transform_library/elementwise.mlir
@@ -28,12 +28,9 @@ transform.named_sequence @fuse_elementwise_and_canonicalize(
 // wider than the target's column count for large blocks (placement fails). A
 // fixed thread count avoids both.
 //
-// The count is intentionally hardcoded to 4 for the npu1 4-column array. This
-// sequence is also included by AIE2P (npu2) elementwise scripts, where 4 caps
-// the herd at 4 of the 8 available columns -- correct, but it under-utilizes
-// the array for large blocks. Making the count target-aware (a per-target
-// sequence, or a driver-injected parameter) is left as a follow-up; 4 is kept
-// for now because it is the value validated on npu1 hardware.
+// The count is hardcoded to 4 for the npu1 4-column array. AIE2P (npu2)
+// elementwise scripts include @flatten_tile_forall_aie2p below instead, which
+// tiles into 8 threads to fill the 8-column Strix array.
 transform.named_sequence @flatten_tile_forall(
     %module: !transform.any_op {transform.readonly}) {
   %op = transform.structured.match ops{["linalg.generic"]} in %module
@@ -47,8 +44,37 @@ transform.named_sequence @flatten_tile_forall(
   %op_1 = transform.structured.match ops{["linalg.generic"]} in %module
       : (!transform.any_op) -> !transform.any_op
   %tiled_op_1, %forall_op_1 =
-      // 4 = npu1 column count (hardcoded; see note above for AIE2P/npu2).
+      // 4 = npu1 column count (hardcoded; AIE2P uses the _aie2p variant below).
       transform.structured.tile_using_forall %op_1 num_threads [4]
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  transform.yield
+}
+
+// AIE2P (npu2) variant of @flatten_tile_forall: 8 threads for the 8-column
+// Strix array instead of npu1's 4. Identical otherwise.
+//
+// DEPENDS ON mlir-air PR #1696 (Xilinx/mlir-air): "Preserve launch base offset
+// when splitting L2 memref". The 8-way split this triggers exposed a bug in
+// air-split-l2-memref where the per-iteration air.launch base offset was
+// dropped, so a multi-program (grid > 1) elementwise kernel silently moved
+// only the first program's data on npu2. Without an mlir-air build that
+// contains that fix, grid > 1 produces wrong results here; grid == 1 (a single
+// large block split across the herd) is correct regardless.
+transform.named_sequence @flatten_tile_forall_aie2p(
+    %module: !transform.any_op {transform.readonly}) {
+  %op = transform.structured.match ops{["linalg.generic"]} in %module
+      : (!transform.any_op) -> !transform.any_op
+  %op_flattened = transform.structured.flatten_elementwise %op
+      : (!transform.any_op) -> !transform.any_op
+  %op_res_shared, %new_op = transform.structured.bufferize_to_allocation
+      %op_flattened
+      {memory_space = 1, bufferize_destination_only, emit_dealloc}
+      : !transform.any_op
+  %op_1 = transform.structured.match ops{["linalg.generic"]} in %module
+      : (!transform.any_op) -> !transform.any_op
+  %tiled_op_1, %forall_op_1 =
+      // 8 = npu2/AIE2P column count (Strix). See dependency note above.
+      transform.structured.tile_using_forall %op_1 num_threads [8]
       : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
   transform.yield
 }

--- a/examples/axpy/transform_aie2p.mlir
+++ b/examples/axpy/transform_aie2p.mlir
@@ -16,7 +16,7 @@ module attributes {transform.with_named_sequence} {
         (%arg1) : (!transform.any_op) -> ()
     transform.include @fuse_elementwise_and_canonicalize failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
-    transform.include @flatten_tile_forall failures(propagate)
+    transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
     transform.include @canonicalize_with_cse failures(propagate)
         (%arg1) : (!transform.any_op) -> ()

--- a/examples/gelu/transform_aie2p.mlir
+++ b/examples/gelu/transform_aie2p.mlir
@@ -18,7 +18,7 @@ module attributes {transform.with_named_sequence} {
         (%arg1) : (!transform.any_op) -> ()
     transform.include @fuse_elementwise_and_canonicalize failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
-    transform.include @flatten_tile_forall failures(propagate)
+    transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
     transform.include @canonicalize_with_cse failures(propagate)
         (%arg1) : (!transform.any_op) -> ()

--- a/examples/leaky_relu/transform_aie2p.mlir
+++ b/examples/leaky_relu/transform_aie2p.mlir
@@ -16,7 +16,7 @@ module attributes {transform.with_named_sequence} {
         (%arg1) : (!transform.any_op) -> ()
     transform.include @fuse_elementwise_and_canonicalize failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
-    transform.include @flatten_tile_forall failures(propagate)
+    transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
     transform.include @canonicalize_with_cse failures(propagate)
         (%arg1) : (!transform.any_op) -> ()

--- a/examples/relu/transform_aie2p.mlir
+++ b/examples/relu/transform_aie2p.mlir
@@ -17,7 +17,7 @@ module attributes {transform.with_named_sequence} {
         (%arg1) : (!transform.any_op) -> ()
     transform.include @fuse_elementwise_and_canonicalize failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
-    transform.include @flatten_tile_forall failures(propagate)
+    transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
     transform.include @canonicalize_with_cse failures(propagate)
         (%arg1) : (!transform.any_op) -> ()

--- a/examples/sigmoid/transform_aie2p.mlir
+++ b/examples/sigmoid/transform_aie2p.mlir
@@ -24,7 +24,7 @@ module attributes {transform.with_named_sequence} {
     transform.include @fuse_elementwise_and_canonicalize failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
 
-    // Phase 3: Flatten + tile forall [256]
+    // Phase 3: Flatten + tile across the herd (num_threads [8] for AIE2P)
     transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
 

--- a/examples/sigmoid/transform_aie2p.mlir
+++ b/examples/sigmoid/transform_aie2p.mlir
@@ -25,7 +25,7 @@ module attributes {transform.with_named_sequence} {
         (%arg1) : (!transform.any_op) -> ()
 
     // Phase 3: Flatten + tile forall [256]
-    transform.include @flatten_tile_forall failures(propagate)
+    transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
 
     // Phase 4: Canonicalization

--- a/examples/silu/transform_aie2p.mlir
+++ b/examples/silu/transform_aie2p.mlir
@@ -17,7 +17,7 @@ module attributes {transform.with_named_sequence} {
         (%arg1) : (!transform.any_op) -> ()
     transform.include @fuse_elementwise_and_canonicalize failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
-    transform.include @flatten_tile_forall failures(propagate)
+    transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
     transform.include @canonicalize_with_cse failures(propagate)
         (%arg1) : (!transform.any_op) -> ()

--- a/examples/swiglu/transform_aie2p.mlir
+++ b/examples/swiglu/transform_aie2p.mlir
@@ -16,7 +16,7 @@ module attributes {transform.with_named_sequence} {
         (%arg1) : (!transform.any_op) -> ()
     transform.include @fuse_elementwise_and_canonicalize failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
-    transform.include @flatten_tile_forall failures(propagate)
+    transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
     transform.include @canonicalize_with_cse failures(propagate)
         (%arg1) : (!transform.any_op) -> ()

--- a/examples/vec-add/transform_aie2p.mlir
+++ b/examples/vec-add/transform_aie2p.mlir
@@ -14,7 +14,7 @@ module attributes {transform.with_named_sequence} {
       %arg1: !transform.any_op {transform.readonly}) {
 
     // No Phase 1/2 for vec-add (no elementwise fusion needed)
-    transform.include @flatten_tile_forall failures(propagate)
+    transform.include @flatten_tile_forall_aie2p failures(propagate)
         (%arg1) : (!transform.any_op) -> ()
     transform.include @canonicalize_with_cse failures(propagate)
         (%arg1) : (!transform.any_op) -> ()

--- a/utils/mlir-air-hash.txt
+++ b/utils/mlir-air-hash.txt
@@ -1,3 +1,3 @@
-Commit: 9377b0e
-Timestamp: 2026060303
+Commit: 3cdaa6a
+Timestamp: 2026063004
 Version: 0.0.1


### PR DESCRIPTION
## Summary

Follow-up to #70 (npu1 `num_threads [4]`). On npu2 (AIE2P / Strix) the array is **8 columns** wide, so tiling into 4 threads leaves half the array idle.

- Adds `@flatten_tile_forall_aie2p` (8-thread variant) to `transform_library/elementwise.mlir`.
- Points all 8 AIE2P elementwise scripts at it: vec-add, relu, silu, gelu, sigmoid, swiglu, axpy, leaky_relu.
- Bumps the mlir-air pin to `3cdaa6a` (see below).
- npu1 `@flatten_tile_forall` and the `aie2` scripts are unchanged.

## Dependency: mlir-air #1696 (merged, pinned here)

Correct **multi-program (grid > 1)** execution on npu2 depends on **[Xilinx/mlir-air#1696](https://github.com/Xilinx/mlir-air/pull/1696)** — *"Preserve launch base offset when splitting L2 memref"*.

The 8-way split this PR introduces is what exposes the mlir-air bug: `air-split-l2-memref` dropped the per-iteration `air.launch` base offset (`launch_idx * tile`) when splitting the L2 buffer across the 8 columns, so every launch iteration collapsed onto block 0. Without the fix, `grid > 1` moved only the first program's data on npu2.

Status: #1696 is **merged**; this PR bumps `utils/mlir-air-hash.txt` from `9377b0e` → **`3cdaa6a`** (the released wheel `mlir_air-0.0.1.2026063004+3cdaa6a`, which contains the fix). The matching `mlir-aie` (`1.3.2.dev115+g2401e53`) resolves transitively via the air wheel's `[aie]` extra.

## Problem size coverage (npu2 / Strix, validated against released wheel `2026063004+3cdaa6a`)

`vec-add` (bf16), validated on hardware:

| Mode | Shape swept | Result |
|---|---|---|
| Single program (`grid == 1`, `N == BLOCK`) | `BLOCK` 128 → 65536 (pow2) | all pass |
| Multi-program (`grid == 8`, `N == 8 * BLOCK`) | `BLOCK` 128 → 32768 (pow2) | all pass |
| Canonical `examples/vec-add/vec-add.py` (`BLOCK == 1024`, `N` 1024 → 32768 ⇒ `grid` 1 → 32) | — | all asserts pass |

`grid == 1` is the widest single-program reach (a large block split across the 8-core herd); `grid > 1` (many smaller programs) is what mlir-air #1696 unblocks. Before this PR (`tile_sizes [256]` shared with npu1) npu2 failed to compile for blocks that folded the forall, and overflowed placement for large blocks.

### Limits / not covered
- **`BLOCK < 128`**: not supported. The 16-lane `tile_using_for` vectorize loop folds to a single trip and is eliminated, corrupting results (same floor as #70 on npu1).
- **Large single blocks**: bounded by the L2 MemTile capacity (the staged result + inputs must fit); 65536 bf16 fits, larger blocks will eventually exceed L2.
- **Masked `tl.load`/`tl.store(..., mask=...)`**: unsupported — independent backend limitation, not addressed here.
- Coverage above is `vec-add` only; the other elementwise scripts (relu, silu, gelu, sigmoid, swiglu, axpy, leaky_relu) share the same `@flatten_tile_forall_aie2p` path but have not been individually hardware-swept.

## Why two sequences instead of one

`@flatten_tile_forall` and `@flatten_tile_forall_aie2p` differ only in the thread count (4 vs 8) — a genuine per-target hardware value. Factoring the shared body into a helper would require the library's first use of nested `transform.include` (currently unused) to save ~6 lines, so the explicit pair is kept.

## Test plan
- [x] Land mlir-air #1696, bump `utils/mlir-air-hash.txt` (→ `3cdaa6a`).
- [x] Land #70 (merged; this PR rebased onto `main`).
- [x] npu2 hardware validation of `vec-add` grid>1 against the released wheel.
- [x] CI npu2 run of the full elementwise example set.
