### PR TITLE
Add live examples dashboard link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ A triton python package with a new amd_triton_npu backend is also pip installed 
 
 ### Run examples
 
+Browse the full set of available operators, their supported datatypes, and AIE2/AIE2P coverage in the live [examples dashboard](https://amd.github.io/Triton-XDNA/).
+
 Please make sure to run `source {path_to_xrt}/setup.sh` before running examples.
 The test also depends on PyTorch as CPU reference.
 


### PR DESCRIPTION
## Summary
- Adds a one-line pointer to the live GitHub Pages examples dashboard (https://amd.github.io/Triton-XDNA/) in the README's "Run examples" section.
- Restores discoverability of the operator dashboard that was lost when the auto-generated `examples/README.md` was removed in `a188071`. Nothing auto-generated is re-committed.

## Test plan
- [x] Confirm the rendered README link resolves to https://amd.github.io/Triton-XDNA/

🤖 Generated with [Claude Code](https://claude.com/claude-code)