### PR TITLE
Register qwen2_5 in examples dashboard as an end-to-end model

### DIFF
--- a/examples/generate_readme.py
+++ b/examples/generate_readme.py
@@ -156,6 +156,17 @@ EXAMPLES = [
             "composed from Triton kernels, running across iGPU and NPU."
         ),
     },
+    {
+        "kind": "model",
+        "name": "Qwen2.5",
+        "path": "qwen2_5",
+        "datatypes": "bf16",
+        "description": (
+            "End-to-end Qwen2.5-Instruct inference (0.5B/1.5B) composed from "
+            "Triton kernels, with KV-cached autoregressive generation running "
+            "across iGPU and NPU."
+        ),
+    },
 ]
 
 # Directories to ignore when verifying registry completeness


### PR DESCRIPTION
## Summary
- The `qwen2_5/` example added in #75 was never added to the `EXAMPLES` registry in `examples/generate_readme.py`, so the "Generate Examples Dashboard" workflow's `--verify` step failed (`WARNING: qwen2_5/ is not in the EXAMPLES registry`), breaking the dashboard build on `main` ([run 29140410489](https://github.com/amd/Triton-XDNA/actions/runs/29140410489)).
- Adds a `model` registry entry for Qwen2.5 (0.5B/1.5B, bf16), mirroring the GPT-2 fix from #74.

## Test plan
- [x] `python3 examples/generate_readme.py --output index.md --base-url ... --verify` no longer flags `qwen2_5/`
- [x] All git-tracked example directories are present in the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)