### PR TITLE
Build Windows wheels for Python 3.13/3.14

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -157,9 +157,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Python matrix is narrower than Linux: Xilinx publishes mlir-air
-        # Windows wheels only for cp310/cp311/cp312 (no cp313/cp314).
-        python_version: ["3.10", "3.11", "3.12"]
+        # Matches the Linux matrix. Xilinx began publishing mlir-air/mlir-aie
+        # Windows wheels for cp313/cp314 in mid-May 2026, so the earlier
+        # cp310-cp312 cap is no longer needed. 3.13 is the version that also
+        # matches the prebuilt pyxrt.pyd shipped in the XRT Windows SDK.
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
       # Pinned XRT Windows SDK release. Provides headers, xrt_coreutil.lib,
@@ -338,7 +340,7 @@ jobs:
             **Build Date:** ${{ steps.commit-info.outputs.datetime }}
 
             Linux wheels: Python 3.10–3.14 (manylinux_x86_64)
-            Windows wheels: Python 3.10–3.12 (win_amd64)
+            Windows wheels: Python 3.10–3.14 (win_amd64)
 
             ### Installation (Linux)
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ compilation pipeline (Triton → MLIR → xclbin → XRT dispatch) runs natively
 
 - **Windows 10/11** (x64)
 - **Visual Studio 2022** with "Desktop development with C++" workload
-- **Python 3.10, 3.11, or 3.12** (Xilinx Windows wheels do not yet support 3.13+)
+- **Python 3.10–3.14** (3.13 recommended). Prebuilt Windows wheels are published
+  for all of these versions; 3.13 is recommended because it matches the prebuilt
+  `pyxrt.pyd` in the current XRT Windows SDK (see below), so the runtime binding
+  works without building it from source.
 - **CMake 3.20+** and **Ninja** (via pip or standalone)
 - **AMD NPU driver** (installs `xrt_coreutil.dll` runtime)
 
@@ -157,6 +160,21 @@ folder is `xrt_sdk/`) to `C:\Program Files\AMD\xrt`:
 #   C:\Program Files\AMD\xrt\include\xrt\xrt_bo.h
 #   C:\Program Files\AMD\xrt\lib\xrt_coreutil.lib
 ```
+
+The same zip also contains the runtime Python binding `pyxrt.pyd` at
+`xrt_sdk/xrt/python/pyxrt.pyd`, which is required at execution time (the NPU
+launcher does `import pyxrt`). Copy it onto your interpreter's import path:
+
+```powershell
+# The current pyxrt.pyd targets Python 3.13. On a 3.13 venv, copy it into
+# site-packages (or any directory on PYTHONPATH):
+Copy-Item "path\to\xrt_sdk\xrt\python\pyxrt.pyd" ".\venv\Lib\site-packages\"
+```
+
+`pyxrt.pyd` loads `xrt_coreutil.dll` at import time, so ensure the AMD NPU driver
+is installed (it provides that DLL) and on `PATH`. On a Python version other than
+the one the `.pyd` targets, importing it raises `ImportError: DLL load failed`;
+in that case, build `pyxrt` from source against your interpreter.
 
 Run the automated environment setup (must be dot-sourced so PATH/env vars
 persist in the current shell):
@@ -223,7 +241,10 @@ python vec-add.py
 
 ### Windows Known Limitations
 
-- Python 3.10, 3.11, and 3.12 only — Xilinx does not publish `mlir-air` /
-  `mlir-aie` Windows wheels for 3.13+ yet
+- Python 3.10–3.14 supported; 3.13 recommended so the prebuilt `pyxrt.pyd` in the
+  XRT Windows SDK can be used as-is. On other versions, build `pyxrt` from source
+  to match your interpreter
+- `pyxrt.pyd` (from the XRT Windows SDK zip) must be on `PYTHONPATH` /
+  site-packages, and the AMD NPU driver's `xrt_coreutil.dll` must be on `PATH`
 - xclbinutil and aiebu-asm must be on PATH (from XRT Windows SDK)
 - NPU driver must be installed


### PR DESCRIPTION
## Summary

Extends the Windows wheel build matrix in `nightly-wheels.yml` from cp310–cp312 to **cp310–cp314**, matching the Linux matrix, and documents the previously-missing `pyxrt.pyd` runtime setup on Windows.

## Why

The Windows wheel job was capped at 3.10–3.12 with the comment *"Xilinx publishes mlir-air Windows wheels only for cp310/cp311/cp312 (no cp313/cp314)."* That was **true when the job was added (2026-05-07)** but is now stale:

| Event | Date |
|-------|------|
| Windows wheel matrix added (capped at 3.12) | 2026-05-07 |
| First mlir-air cp313 **Windows** wheel published by Xilinx | 2026-05-18 |
| First mlir-aie cp313 **Windows** wheel published by Xilinx | 2026-05-20 |

`triton-windows`, `mlir-air`, `mlir-aie`, and `llvm-aie` now all ship Windows wheels for 3.10–3.14, so there's no remaining blocker to building triton-xdna Windows wheels for 3.13/3.14.

## Relation to #77

The prebuilt `pyxrt.pyd` in the XRT Windows SDK targets **Python 3.13 only**. Because there was no 3.13 triton-xdna Windows wheel, users were pushed onto 3.10–3.12, where the prebuilt `pyxrt.pyd` fails to load (`ImportError: DLL load failed`), forcing a source build of pyxrt (#77). Shipping a 3.13 Windows wheel lets everything line up on 3.13 with no source build.

## Changes

- `nightly-wheels.yml`: Windows matrix → `["3.10", "3.11", "3.12", "3.13", "3.14"]`; updated the stale comment; release-notes text now says *Windows wheels: Python 3.10–3.14*.
- `README.md`: Windows requirement updated to 3.10–3.14 (3.13 recommended); added the missing `pyxrt.pyd` placement step and `xrt_coreutil.dll`/PATH note; corrected the Known Limitations bullet.

## Test plan

- [ ] Trigger the `build-wheels-windows` job (via `workflow_dispatch`) and confirm cp313 + cp314 `win_amd64` wheels build and upload.
- [ ] Smoke-test the resulting cp313 wheel on a Windows NPU host with the SDK's `pyxrt.pyd` (no source build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)