### PR TITLE
Fix triton_shared cold-build race (missing TPtrTableGen dependency)

### DIFF
--- a/third_party/triton_shared.patch
+++ b/third_party/triton_shared.patch
@@ -1,3 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5792dcb..aa80cf5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,6 +28,11 @@ if (TRITON_SHARED_BUILD_CPU_BACKEND)
+ 
+     add_triton_plugin(TritonShared ${CMAKE_CURRENT_SOURCE_DIR}/triton_shared.cc LINK_LIBS TritonSharedAnalysis TritonTilingExtIR ${conversion_libs} ${extension_libs} MLIRSparseTensorTransforms MLIRControlFlowTransforms MLIRTensorInferTypeOpInterfaceImpl)
+     target_link_libraries(TritonShared PRIVATE Python3::Module pybind11::headers)
++    # triton_shared.cc includes TPtrDialect.h -> TPtrDialect.h.inc, which is
++    # emitted by the TPtrTableGen target. Without this explicit dependency a
++    # parallel/cold build can compile triton_shared.cc before tablegen runs,
++    # failing with "TPtrDialect.h.inc file not found".
++    add_dependencies(TritonShared TPtrTableGen)
+ endif()
+ 
+ # Add symlinks to selected pytest files in triton. The tests are imported into triton-shared’s test folder to
 diff --git a/backend/driver.py b/backend/driver.py
 index a4ac9ef..69f50b3 100644
 --- a/backend/driver.py


### PR DESCRIPTION
## Problem
`build.yml` on `main` is red (runs [29359138455](https://github.com/amd/Triton-XDNA/actions/runs/29359138455)), failing during the triton_shared build:

```
third_party/triton_shared/include/triton-shared/Dialect/TPtr/IR/TPtrDialect.h:20:10:
fatal error: 'triton-shared/Dialect/TPtr/IR/TPtrDialect.h.inc' file not found
```

## Root cause
The `TritonShared` plugin target compiles `triton_shared.cc`, which includes `TPtrDialect.h` → `TPtrDialect.h.inc` (emitted by the `TPtrTableGen` tablegen target). But the target neither links `TPtrIR` nor declares a dependency on `TPtrTableGen`, so under a parallel/cold `-j8` build the `.cc` can compile before tablegen runs.

A warm ccache normally hides this by reusing the cached object. Main went red only after a GitHub **cache-service outage** (`Failed to restore: Cache service responded with 400`) forced a cold compile, and then stayed red because the poisoned cache keeps recompiling that object cold (the re-run failed identically with ccache healthy).

This is a pre-existing latent race in the triton_shared submodule CMake — not caused by the mlir-air/PDI change in #79 (that merge touched only Python + the mlir-air pin; the triton_shared source built here is byte-identical to the previously-green #78).

## Fix
Add an explicit `add_dependencies(TritonShared TPtrTableGen)` in the triton_shared submodule CMake and regenerate `third_party/triton_shared.patch`, making cold builds deterministic.

## Test plan
- [x] Regenerated patch applies cleanly against the pinned submodule SHA (`git apply --check`).
- [x] CI `build.yml` green on this PR (cold build now orders tablegen before the plugin compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)