### PR TITLE
Bump mlir-air (d3c5f87) / mlir-aie v1.4.0 and fix v1.4.0 compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       echo "mlir-air timestamp: $MLIR_AIR_TIMESTAMP"
       python3 -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHORT_MLIR_AIR_COMMIT_HASH.no.rtti" \
           -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
-          -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
+          -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
           -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
       # The [aie] extra requires llvm-aie without a version pin. Force an
       # upgrade so we always test against the latest nightly wheel.

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -347,7 +347,7 @@ jobs:
             ```bash
             pip install triton-xdna \
               --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/latest-wheels \
-              --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
+              --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
               --find-links https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly \
               --find-links https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
             ```
@@ -357,7 +357,7 @@ jobs:
             ```powershell
             pip install triton-xdna `
               --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/latest-wheels `
-              --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 `
+              --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 `
               --find-links https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly `
               --find-links https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
             ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python3 -m pip install --upgrade pip
 # Install triton-xdna from GitHub Releases
 pip install triton-xdna \
   --find-links https://github.com/amd/Triton-XDNA/releases/expanded_assets/latest-wheels \
-  --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
+  --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
   --find-links https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly \
   --find-links https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
 ```
@@ -62,7 +62,7 @@ pip install triton-xdna \
 **Note:** To install from a local wheel file:
 ```bash
 pip install /path/to/triton_xdna-*.whl \
-  --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
+  --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
   --find-links https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly \
   --find-links https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
 ```
@@ -79,7 +79,7 @@ pip install cmake pybind11 nanobind wheel ninja pytest setuptools Cython
 
 # Install triton-xdna from source and all dependencies automatically
 pip install . --no-build-isolation \
-  --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
+  --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
   --find-links https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly \
   --find-links https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
 ```
@@ -199,7 +199,7 @@ pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install triton-windows
 pip install "mlir_air[aie]" `
   -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti `
-  -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 `
+  -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 `
   -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 ```
 

--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -18,7 +18,7 @@ from triton.runtime.cache import get_cache_manager
 from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
 
-import aie.compiler.aiecc.main as aiecc
+import aie
 import air.compiler.aircc.main as aircc
 from air.compiler.util import run_transform
 from air.ir import *
@@ -385,11 +385,10 @@ def _get_aie_test_utils_path() -> str:
     custom = os.getenv("AIE_TEST_UTILS_DIR")
     if custom:
         return custom
+    # aie.__file__ is <mlir_aie>/python/aie/__init__.py; three parents up is
+    # the mlir_aie install root that contains runtime_lib/.
     path = (
-        Path(aiecc.__file__).parent.parent.parent.parent.parent
-        / "runtime_lib"
-        / "x86_64"
-        / "test_lib"
+        Path(aie.__file__).parent.parent.parent / "runtime_lib" / "x86_64" / "test_lib"
     )
     return path
 
@@ -1492,28 +1491,33 @@ def _aircc_compile(air_mlir_path, output_format, npu_version, air_proj_path):
     aircc_binary_name = "aircc.exe" if IS_WINDOWS else "aircc"
     aircc_bin = _find_mlir_air_binary(aircc_binary_name)
 
-    # On Windows, construct peano path from llvm-aie package and
-    # add mlir_aie/bin to PATH so aircc can find aiecc.exe
+    # Resolve the peano (llvm-aie) install root and pass it explicitly to
+    # aircc. Without --peano, aiecc falls back to whichever opt/llc is on PATH
+    # (e.g. a system /usr/bin/opt) which lacks the aie2p/aie2 target and fails
+    # with "unrecognized architecture 'aie2p'".
+    opt_name = "opt.exe" if IS_WINDOWS else "opt"
     peano_flag = "--peano="
+    peano_dir = os.environ.get("LLVM_BINARY_DIR", "")
+    if peano_dir:
+        # LLVM_BINARY_DIR points to bin/, peano wants parent
+        peano_flag = f"--peano={str(Path(peano_dir).parent)}"
+    else:
+        # Auto-detect from pip-installed llvm-aie package
+        try:
+            dist = importlib.metadata.distribution("llvm-aie")
+            llvm_aie_root = Path(dist._path.parent) / "llvm-aie"
+            if (llvm_aie_root / "bin" / opt_name).exists():
+                peano_flag = f"--peano={llvm_aie_root}"
+        except Exception:
+            pass
+    # Also check PEANO_INSTALL_DIR env var
+    if peano_flag == "--peano=":
+        peano_env = os.environ.get("PEANO_INSTALL_DIR", "")
+        if peano_env and os.path.isdir(peano_env):
+            peano_flag = f"--peano={peano_env}"
+
+    # On Windows, add mlir_aie/bin to PATH so aircc can find aiecc.exe
     if IS_WINDOWS:
-        peano_dir = os.environ.get("LLVM_BINARY_DIR", "")
-        if peano_dir:
-            # LLVM_BINARY_DIR points to bin/, peano wants parent
-            peano_flag = f"--peano={str(Path(peano_dir).parent)}"
-        else:
-            # Auto-detect from pip-installed llvm-aie package
-            try:
-                dist = importlib.metadata.distribution("llvm-aie")
-                llvm_aie_root = Path(dist._path.parent) / "llvm-aie"
-                if (llvm_aie_root / "bin" / "opt.exe").exists():
-                    peano_flag = f"--peano={llvm_aie_root}"
-            except Exception:
-                pass
-        # Also check PEANO_INSTALL_DIR env var
-        if peano_flag == "--peano=":
-            peano_env = os.environ.get("PEANO_INSTALL_DIR", "")
-            if peano_env and os.path.isdir(peano_env):
-                peano_flag = f"--peano={peano_env}"
         # Ensure aiecc is findable
         try:
             import mlir_aie

--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -1496,24 +1496,33 @@ def _aircc_compile(air_mlir_path, output_format, npu_version, air_proj_path):
     # (e.g. a system /usr/bin/opt) which lacks the aie2p/aie2 target and fails
     # with "unrecognized architecture 'aie2p'".
     opt_name = "opt.exe" if IS_WINDOWS else "opt"
+
+    def _is_peano_root(root) -> bool:
+        # A valid peano root has the AIE-aware opt under bin/.
+        return bool(root) and (Path(root) / "bin" / opt_name).exists()
+
     peano_flag = "--peano="
+    # 1) LLVM_BINARY_DIR points to bin/, peano wants the parent. Only trust it
+    #    if that parent actually contains bin/opt, otherwise fall through so a
+    #    misconfigured LLVM_BINARY_DIR doesn't feed aircc a bogus --peano.
     peano_dir = os.environ.get("LLVM_BINARY_DIR", "")
     if peano_dir:
-        # LLVM_BINARY_DIR points to bin/, peano wants parent
-        peano_flag = f"--peano={str(Path(peano_dir).parent)}"
-    else:
-        # Auto-detect from pip-installed llvm-aie package
+        candidate = Path(peano_dir).parent
+        if _is_peano_root(candidate):
+            peano_flag = f"--peano={candidate}"
+    # 2) Auto-detect from the pip-installed llvm-aie package.
+    if peano_flag == "--peano=":
         try:
             dist = importlib.metadata.distribution("llvm-aie")
-            llvm_aie_root = Path(dist._path.parent) / "llvm-aie"
-            if (llvm_aie_root / "bin" / opt_name).exists():
-                peano_flag = f"--peano={llvm_aie_root}"
+            candidate = Path(dist.locate_file("")) / "llvm-aie"
+            if _is_peano_root(candidate):
+                peano_flag = f"--peano={candidate}"
         except Exception:
             pass
-    # Also check PEANO_INSTALL_DIR env var
+    # 3) Fall back to the PEANO_INSTALL_DIR env var.
     if peano_flag == "--peano=":
         peano_env = os.environ.get("PEANO_INSTALL_DIR", "")
-        if peano_env and os.path.isdir(peano_env):
+        if _is_peano_root(peano_env):
             peano_flag = f"--peano={peano_env}"
 
     # On Windows, add mlir_aie/bin to PATH so aircc can find aiecc.exe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 # Installation command:
 # pip install triton-xdna \
 #   --find-links https://github.com/amd/Triton-XDNA/releases/expanded_assets/latest-wheels \
-#   --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
+#   --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
 #   --find-links https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly \
 #   --find-links https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
 

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -33,7 +33,12 @@ if [[ "$MLIR_AIE_INSTALL_DIR" == "" ]]; then
     # python package under <site-packages>/mlir_aie.
     MLIR_AIE_LOCATION="$(python3 -m pip show mlir_aie_no_rtti 2>/dev/null | grep ^Location: | awk '{print $2}')"
     if [[ "$MLIR_AIE_LOCATION" == "" ]]; then
-        MLIR_AIE_LOCATION="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')"
+        MLIR_AIE_LOCATION="$(python3 -m pip show mlir_aie 2>/dev/null | grep ^Location: | awk '{print $2}')"
+    fi
+    if [[ "$MLIR_AIE_LOCATION" == "" ]]; then
+        echo "ERROR: could not locate an installed mlir_aie(_no_rtti) package." >&2
+        echo "       Install it (e.g. via mlir_air[aie]) or set MLIR_AIE_INSTALL_DIR manually." >&2
+        return 1 2>/dev/null || exit 1
     fi
     export MLIR_AIE_INSTALL_DIR="${MLIR_AIE_LOCATION}/mlir_aie"
 fi

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -18,7 +18,7 @@ MLIR_AIR_TIMESTAMP=$(awk -v kw="Timestamp:" '$0 ~ kw {for (i=1; i<NF; i++) if ($
 echo "mlir-air timestamp: $MLIR_AIR_TIMESTAMP"
 python3 -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHORT_MLIR_AIR_COMMIT_HASH.no.rtti" \
     -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
-    -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
+    -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.4.0 \
     -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
 # The [aie] extra requires llvm-aie without a version pin. To track the
@@ -28,7 +28,14 @@ python3 -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SH
 python3 -m pip install --upgrade llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
 if [[ "$MLIR_AIE_INSTALL_DIR" == "" ]]; then
-    export MLIR_AIE_INSTALL_DIR="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
+    # The [aie] extra installs the no-RTTI wheel (dist name: mlir_aie_no_rtti),
+    # falling back to the RTTI wheel (dist name: mlir_aie). Both unpack the
+    # python package under <site-packages>/mlir_aie.
+    MLIR_AIE_LOCATION="$(python3 -m pip show mlir_aie_no_rtti 2>/dev/null | grep ^Location: | awk '{print $2}')"
+    if [[ "$MLIR_AIE_LOCATION" == "" ]]; then
+        MLIR_AIE_LOCATION="$(python3 -m pip show mlir_aie | grep ^Location: | awk '{print $2}')"
+    fi
+    export MLIR_AIE_INSTALL_DIR="${MLIR_AIE_LOCATION}/mlir_aie"
 fi
 
 export PATH="${MLIR_AIE_INSTALL_DIR}/bin:${PATH}"

--- a/utils/mlir-air-hash.txt
+++ b/utils/mlir-air-hash.txt
@@ -1,3 +1,3 @@
-Commit: c7ee42f
-Timestamp: 2026071405
+Commit: d3c5f87
+Timestamp: 2026073005
 Version: 0.0.1


### PR DESCRIPTION
## Summary

MLIR-AIR updated its pinned mlir-aie to the **v1.4.0** release. This bumps our pins to match and fixes the compatibility breaks that surfaced on the new stack.

- **Pins:** `utils/mlir-air-hash.txt` → mlir-air `d3c5f87` / `2026073005`, whose `[aie]` extra pins `mlir_aie_no_rtti==1.4.0`. The mlir-aie find-links are repointed to the `v1.4.0` tagged-release page across `env_setup.sh`, CI, README, and `pyproject.toml` — the rolling `latest-wheels-no-rtti-2` page only ships `1.3.x` and `1.4.1.dev*` wheels, not exact `1.4.0`, so it cannot satisfy the `==1.4.0` pin.
- **driver.py — removed aiecc module:** mlir-aie 1.4.0 removed the `aie.compiler.aiecc` Python module (aiecc is now only a `bin/` binary). `import aie.compiler.aiecc.main` broke Triton backend discovery entirely. Switched to importing the top-level `aie` package and deriving the install root from `aie.__file__`.
- **driver.py — peano path:** the peano (llvm-aie) root was only passed to `aircc` on Windows. On Linux `--peano=` was empty, so the new aiecc fell back to a system `opt`/`llc` that lacks the `aie2p` target and failed with `unrecognized architecture 'aie2p'`. Peano resolution is now cross-platform.
- **env_setup.sh — install dir detection:** `MLIR_AIE_INSTALL_DIR` was derived from `pip show mlir_aie`, but the `[aie]` extra installs the no-RTTI wheel (`mlir_aie_no_rtti`), so it resolved to a bogus `/mlir_aie`. Now checks the no-rtti dist name first, falling back to the RTTI name.

## Test plan

Ran the full example suite on **Strix (npu2 / AIE2P)** hardware with the new stack (mlir-air `d3c5f87` + mlir-aie `1.4.0` + llvm-aie nightly):

```
python scripts/run_tests.py --device aie2p --verbose --timeout 1200
  Passed: 17    Failed: 1    Skipped: 3
```

- **Passed (17):** average_pool, axpy, gelu, leaky_relu, matmul_bf16_m64_n64_k64, matmul_f32_m64_n32_k16_padded_atransposed, matmul_i8_m128_n64_k64, matmul_i8_m64_n64_k64, relu, rms_norm, sigmoid, silu, swiglu, test_layernorm, test_softmax, vec-add, weighted_rms_norm
- **Skipped (3):** autotune-matmul, gpt2, qwen2_5 — no `transform_aie2p.mlir` present
- **Failed (1):** `matvec` — numerical mismatch (garbage output). This is an **untracked WIP example** (not committed / not in this PR) and it **fails identically on the previously-pinned stack**, so it is pre-existing and not a regression from this bump.

All committed examples that have an `aie2p` transform pass end-to-end (compile → execute on NPU → match torch reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
