### PR TITLE
Fix npu1 i8 matmul pack size, and stop skipping scriptless examples

### DIFF
--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -1063,14 +1063,6 @@ def _matmul_transform_params(info, npu_version):
     if info is None:
         return None
 
-    # Pack sizes and herd caps are architecture-specific.
-    if npu_version == "npu2":
-        pack_m, pack_n, pack_k = 8, 8, 8
-        cap_m, cap_n = 4, 4
-    else:  # npu1 (Phoenix, 4x2 array)
-        pack_m, pack_n, pack_k = 4, 4, 8
-        cap_m, cap_n = 4, 2
-
     # dtype -> accumulator / contract-input / bf16-emulation rules.
     in_elem, out_elem = info["in_elem"], info["out_elem"]
     if in_elem == "f32":
@@ -1078,9 +1070,28 @@ def _matmul_transform_params(info, npu_version):
     elif in_elem == "bf16":
         accum_type, contract_input_type, bf16_emulation = "f32", None, False
     elif in_elem == "i8":
-        accum_type, contract_input_type, bf16_emulation = "i32", "i16", False
+        # No contract-input cast: the AIEVec lowering recovers signedness from
+        # the arith.extsi it peels off the operands, so casting to i16 first
+        # only obscures it.
+        accum_type, contract_input_type, bf16_emulation = "i32", None, False
     else:
         return None
+
+    # Pack sizes are the hardware MAC shape, so they depend on the element type
+    # as well as the target; herd caps depend only on the array. Note
+    # pack_sizes is ordered (M, N, K) while a MAC shape is written (M, K, N) --
+    # the two coincide only when the shape is cubic, which is why npu2 does not
+    # need to distinguish them.
+    if npu_version == "npu2":
+        # AIE2P has an 8x8x8 MAC for both bf16 and i8.
+        pack_m, pack_n, pack_k = 8, 8, 8
+        cap_m, cap_n = 4, 4
+    else:  # npu1 (Phoenix / AIE2, 4x2 array)
+        # IsValidAIE2MatMulShapeAndType lists exactly one shape per input type
+        # on AIE2: bf16 is 4x8 x 8x4 -> 4x4, i8 is 4x8 x 8x8 -> 4x8.
+        pack_m, pack_k = 4, 8
+        pack_n = 8 if in_elem == "i8" else 4
+        cap_m, cap_n = 4, 2
 
     m, k, n = info["m"], info["k"], info["n"]
     # Pack requires exact divisibility of each dim by its pack size.

--- a/amd_triton_npu/backend/matmul_transform.py
+++ b/amd_triton_npu/backend/matmul_transform.py
@@ -27,10 +27,10 @@ Usage:
         l1_m=64, l1_n=64, l2_k=64, pack_sizes=(4, 4, 8),
     )
 
-    # Integer matmul (i8->i32 accumulation, i16 contract inputs)
+    # Integer matmul (i8 -> i32 accumulation, inputs left as-is)
     mlir = generate_matmul_transform(
         l1_m=64, l1_n=128, l2_k=256,
-        pack_sizes=(8, 8, 8), accum_type="i32", contract_input_type="i16",
+        pack_sizes=(8, 8, 8), accum_type="i32",
     )
 """
 
@@ -55,16 +55,21 @@ def generate_matmul_transform(
         l2_k: L3-to-L2 copy tile size along K dimension. Also determines
             the K-reduction tile in packed space (l2_k // pack_sizes[2]).
         pack_sizes: Pack sizes for (M, N, K) dimensions matching the
-            hardware microkernel MAC dimensions (mmul_mkn). Typical values:
-            (8, 8, 8) for AIE2P, (4, 4, 8) for AIE2.
+            hardware MAC shape. Note the orderings differ: a MAC shape is
+            written (M, K, N), so (4, 4, 8) here is a 4x8 x 8x4 -> 4x4 MAC.
+            AIE2P is (8, 8, 8) for every type. AIE2 has one shape per input
+            type: (4, 4, 8) for bf16 and (4, 8, 8) for i8.
         accum_type: Element type for the accumulator in vector.contract.
             The vector_type_cast in Phase 11 casts input[2] and output[0]
             to this type. Use "f32" for bf16 matmul, "i32" for i8/i16 matmul.
         contract_input_type: Element type for vector.contract inputs 0,1.
             If set, adds a vector_type_cast to cast the inputs to this type.
-            Use "i16" for i8 matmul (AIE2P native i8xi8->i16 MAC with i32
-            accumulation). Use "bf16" for f32 data with bf16 emulation.
-            If None, inputs are left as-is after vectorization.
+            Use "bf16" for f32 data with bf16 emulation. If None, inputs are
+            left as-is after vectorization.
+            Leave this None for integer matmul: the AIEVec lowering recovers
+            each operand's signedness from the arith.extsi/extui it peels off
+            the contraction, and casting the inputs first discards that. An
+            i8 matmul with a cast here lowers with the wrong MAC signedness.
         bf16_emulation: Shorthand for contract_input_type="bf16". If True
             and contract_input_type is None, sets contract_input_type="bf16".
 
@@ -90,7 +95,9 @@ def generate_matmul_transform(
     # target type. This matches the hardware MAC unit's native input type.
     # - bf16 matmul: inputs stay bf16 (no cast needed)
     # - bf16 emulation (f32 data): cast inputs f32->bf16
-    # - i8 matmul: cast inputs i32->i16 (AIE2P native i8xi8 MAC uses i16 contract)
+    # - integer matmul: no cast. The AIEVec lowering takes each operand's
+    #   signedness from the arith.extsi/extui it peels off the contraction,
+    #   so casting here would drop it and pick the wrong MAC signedness.
     input_cast = ""
     if contract_input_type is not None:
         input_cast = f"""
@@ -408,7 +415,9 @@ if __name__ == "__main__":
         type=str,
         default=None,
         choices=["bf16", "i16", "i32"],
-        help="Cast vector.contract inputs to this type (e.g., i16 for i8 matmul)",
+        help="Cast vector.contract inputs to this type (bf16 for f32 data "
+        "under bf16 emulation). Leave unset for integer matmul, so the AIEVec "
+        "lowering can read operand signedness off the extsi/extui it peels.",
     )
     parser.add_argument(
         "--bf16-emulation",

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -10,12 +10,36 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
-
 # Example directories skipped by default unless explicitly selected via --select
 DEFAULT_SKIPPED_EXAMPLES = {
     "layernorm",
     "load_2d_block",
     "multi_drivers",
+}
+
+# Examples that cannot run without a transform script on a given device, keyed
+# by device. An example with no transform_<device>.mlir is otherwise run
+# scriptless, since the driver derives a schedule for matmul IR; these are the
+# cases where that does not work, listed with the reason so the gap is visible
+# rather than hidden behind a missing file.
+SCRIPTLESS_UNSUPPORTED = {
+    "aie2": {
+        # Not matmul, so there is nothing to auto-generate and the built-in
+        # default transform is used instead; it fails to legalize
+        # airrt.dma_memcpy_nd / airrt.segment_load on npu1.
+        "gelu": "non-matmul; built-in default transform fails to legalize on npu1",
+        "rms_norm": "non-matmul; built-in default transform fails to legalize on npu1",
+        # Auto-generation produces a legal schedule, but the resulting L2->L1
+        # copy needs a buffer descriptor of 32768 32-bit words against a
+        # 16383-word maximum for the tile type.
+        "matmul_i8_m128_n64_k64": "aie.dma_bd length exceeds the npu1 tile maximum",
+        # LLM examples targeting npu2. They drive their own per-kernel
+        # transform scripts, all of which are *_aie2p.mlir, so the single
+        # transform_<device>.mlir convention does not apply to them either.
+        "gpt2": "npu2-only example",
+        "qwen2_5": "npu2-only example",
+    },
+    "aie2p": {},
 }
 
 
@@ -207,7 +231,13 @@ def main():
             print()
             continue
 
-        # Check if transform file exists for the target device
+        # Use the device's transform script when the example ships one. When it
+        # does not, run without AIR_TRANSFORM_TILING_SCRIPT rather than
+        # skipping: the driver derives a schedule for matmul IR, and falls back
+        # to the built-in default otherwise. Skipping on a missing file alone
+        # would hide exactly the cases the scriptless path exists to cover --
+        # only the examples listed in SCRIPTLESS_UNSUPPORTED are skipped, and
+        # each carries the reason.
         transform_path = ex_dir / transform_filename
         if transform_path.exists():
             transform_file = transform_filename
@@ -215,13 +245,17 @@ def main():
                 f"   {transform_filename} detected; will set AIR_TRANSFORM_TILING_SCRIPT"
             )
         else:
-            # No transform file for this device - skip the example
+            reason = SCRIPTLESS_UNSUPPORTED.get(args.device, {}).get(ex_dir.name)
+            if reason:
+                print(f"   ⏭️  SKIP: no {transform_filename} and {reason}")
+                skipped += 1
+                print()
+                continue
+            transform_file = None
             print(
-                f"   ⏭️  SKIP: {transform_filename} not found for device {args.device}"
+                f"   no {transform_filename}; running scriptless "
+                f"(driver derives the schedule)"
             )
-            skipped += 1
-            print()
-            continue
 
         for py_file in py_files:
             total_files += 1


### PR DESCRIPTION
Two related changes: scriptless i8 matmul now compiles and runs correctly on npu1, and `run_tests.py` stops skipping the examples that exercise it.

## 1. npu1 pack sizes depend on the element type

Scriptless i8 matmul does not compile on npu1 today. `_matmul_transform_params` picks the pack size from the target alone, so i8 gets npu1's `(4, 4, 8)`:

```
error: failed to legalize operation 'vector.contract' that was explicitly marked illegal:
  vector<1x1x4x8xi16>, vector<1x1x8x4xi16> into vector<1x1x4x4xi32>
```

`pack_sizes` is ordered `(M, N, K)` while a MAC shape is written `(M, K, N)`, so `(4, 4, 8)` asks for `4x8 × 8x4 → 4x4`. `IsValidAIE2MatMulShapeAndType` lists exactly one shape per input type on AIE2:

| target | dtype | MAC shape | required `pack_sizes` |
|---|---|---|---|
| npu1 / AIE2 | bf16 | `4x8 × 8x4 → 4x4` | `(4, 4, 8)` |
| npu1 / AIE2 | **i8** | `4x8 × 8x8 → 4x8` | **`(4, 8, 8)`** |
| npu2 / AIE2P | both | `8x8x8` | `(8, 8, 8)` |

So the pack size depends on the element type, not just the target. npu2 is unaffected — AIE2P is `8x8x8` for both, which is also why the `(M,N,K)` / `(M,K,N)` distinction never surfaced there.

`contract_input_type` also drops to `None` for i8: the AIEVec lowering recovers signedness from the `arith.extsi` it peels off the contraction operands, so casting to i16 first only hides it. `None` / `"i8"` / `"i16"` were measured to give identical results.

## 2. `run_tests.py` runs scriptless instead of skipping

The runner skipped any example without `transform_<device>.mlir`. That predates scriptless auto-generation, so the examples the feature exists to cover were exactly the ones never exercised — `matmul_i8_m64_n64_k64` reported `SKIP: transform_aie2.mlir not found` on every npu1 run despite working scriptless.

It now falls through to a scriptless run. Examples that genuinely cannot run that way are listed in `SCRIPTLESS_UNSUPPORTED` with a reason that is printed on the skip:

```
⏭️  SKIP: no transform_aie2.mlir and non-matmul; built-in default transform fails to legalize on npu1
⏭️  SKIP: no transform_aie2.mlir and aie.dma_bd length exceeds the npu1 tile maximum
⏭️  SKIP: no transform_aie2.mlir and npu2-only example
```

A default aie2 run: 14 examples with scripts, **1 scriptless (i8, passes)**, 5 skipped with reasons.

## Validation (NPU1 / Phoenix, AIE2)

Against mlir-air `85f638d` / mlir-aie `1.4.1.dev46+g687ff97`, which carries the AIEVec signedness fixes ([#3489](https://github.com/Xilinx/mlir-aie/pull/3489), [#3503](https://github.com/Xilinx/mlir-aie/pull/3503)) this depends on:

- `matmul_i8_m64_n64_k64` **scriptless: exact** over random `int8[-8,8)` with `atol=0 rtol=0`, `pack_sizes=(4, 8, 8)`
- MAC configuration word in the core ELF is **`0x308`** (signed × signed), emitted op `vector<4x8xsi8>, vector<8x8xsi8>`
- bf16 and f32 still resolve to `(4, 4, 8)`; bf16 sweep passes, f32 unchanged
- `run_tests.py`: `vec-add`, `relu`, `sigmoid`, `silu`, `matmul_bf16` pass; i8 now runs and passes

## Notes

`matmul_i8_m128_n64_k64` still fails, on an unrelated pre-existing `aie.dma_bd` length limit (32768 words against a 16383 maximum) rather than on the MAC shape — it is in the skip list for that reason.

The `gelu` / `rms_norm` entries record a real npu1 gap in the non-matmul default transform (`airrt.dma_memcpy_nd` fails to legalize). Listing them keeps the suite honest about it, but the underlying failure is worth fixing separately rather than living in a skip list.