### PR TITLE
Document that npu1 (AIE2) kernel execution is not yet supported on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,18 @@ time.
 ## Windows Support
 
 Native Windows builds are supported using MSVC — no WSL or Linux required. The full
-compilation pipeline (Triton → MLIR → xclbin → XRT dispatch) runs natively on Windows.
+compilation pipeline (Triton → MLIR → xclbin/ELF → XRT dispatch) runs natively on Windows.
+
+**Kernel execution on Windows is currently validated on npu2 (AIE2P) devices only.**
+On npu1 (AIE2) the compile pipeline completes, but dispatch goes through the older
+xclbin/DPU path, which is not yet supported on the Windows NPU driver stack; kernels
+abort with `ERT_CMD_STATE_ABORT` and produce zeroed output. Use Linux for npu1 for
+now. See [#88](https://github.com/amd/Triton-XDNA/issues/88).
 
 ### Windows Requirements
 
 - **Windows 10/11** (x64)
+- **AMD NPU: npu2 (AIE2P)** — npu1 (AIE2) is compile-only on Windows for now
 - **Visual Studio 2022** with "Desktop development with C++" workload
 - **Python 3.10–3.14** (3.13 recommended). Prebuilt Windows wheels are published
   for all of these versions; 3.13 is recommended because it matches the prebuilt
@@ -306,6 +313,11 @@ $env:AIR_TRANSFORM_TILING_SCRIPT = "transform_aie2p.mlir"
 python vec-add.py
 ```
 
+`transform_aie2p.mlir` targets npu2 (AIE2P). The npu1 (AIE2) equivalents —
+`transform_aie2.mlir` and `AMD_TRITON_NPU_TARGET=npu1` — compile successfully on
+Windows but do not yet execute; see the limitation noted under
+[Windows Support](#windows-support).
+
 ### Windows Environment Variables
 
 | Variable | Purpose |
@@ -315,6 +327,11 @@ python vec-add.py
 
 ### Windows Known Limitations
 
+- Kernel execution is currently validated on npu2 (AIE2P) only. npu1 (AIE2)
+  compiles but does not yet execute on Windows — dispatch uses the xclbin/DPU
+  path, which the Windows NPU driver stack does not yet support, so kernels abort
+  (`ERT_CMD_STATE_ABORT`) and outputs come back zeroed. Use Linux for npu1 for
+  now. See [#88](https://github.com/amd/Triton-XDNA/issues/88)
 - Python 3.10–3.14 supported; 3.13 recommended so the prebuilt `pyxrt.pyd` in the
   XRT Windows SDK can be used as-is. On other versions, build `pyxrt` from source
   to match your interpreter

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ time.
 ## Windows Support
 
 Native Windows builds are supported using MSVC — no WSL or Linux required. The full
-compilation pipeline (Triton → MLIR → xclbin/ELF → XRT dispatch) runs natively on Windows.
+compilation pipeline (Triton → MLIR → xclbin/ELF) runs natively on Windows.
 
 **Kernel execution on Windows is currently validated on npu2 (AIE2P) devices only.**
 On npu1 (AIE2) the compile pipeline completes, but dispatch goes through the older
@@ -210,7 +210,8 @@ now. See [#88](https://github.com/amd/Triton-XDNA/issues/88).
 ### Windows Requirements
 
 - **Windows 10/11** (x64)
-- **AMD NPU: npu2 (AIE2P)** — npu1 (AIE2) is compile-only on Windows for now
+- **AMD NPU: npu2 (AIE2P)** to *run* kernels. Building and compiling work on any
+  Windows host (no NPU required); npu1 (AIE2) can compile but not yet execute
 - **Visual Studio 2022** with "Desktop development with C++" workload
 - **Python 3.10–3.14** (3.13 recommended). Prebuilt Windows wheels are published
   for all of these versions; 3.13 is recommended because it matches the prebuilt
@@ -314,8 +315,8 @@ python vec-add.py
 ```
 
 `transform_aie2p.mlir` targets npu2 (AIE2P). The npu1 (AIE2) equivalents —
-`transform_aie2.mlir` and `AMD_TRITON_NPU_TARGET=npu1` — compile successfully on
-Windows but do not yet execute; see the limitation noted under
+`transform_aie2.mlir` with `$env:AMD_TRITON_NPU_TARGET = "npu1"` — compile
+successfully on Windows but do not yet execute; see the limitation noted under
 [Windows Support](#windows-support).
 
 ### Windows Environment Variables


### PR DESCRIPTION
## Summary

The Windows Support section of the README described Windows support as target-independent ("the full compilation pipeline ... runs natively on Windows"), giving a user on npu1 hardware no indication that only the *compile* half works there. That gap is what led to #88, where kernels built and dispatched cleanly but returned all-zero output.

Windows dispatch has so far only been validated on npu2 (AIE2P), which uses the `xrt::elf` + `hw_context(device, elf)` path. npu1 (AIE2) is forced onto the older xclbin/DPU path (`_get_output_format` in `amd_triton_npu/backend/driver.py`), and that path is not yet supported by the Windows NPU driver stack — the command is rejected with `ERT_CMD_STATE_ABORT` and output buffers come back zeroed.

Documentation only; no functional change.

## Changes

Notes the limitation in four places, so it's visible both before and after someone hits it:

- **Windows Support** overview — the primary statement, since that's where the over-broad claim was
- **Windows Requirements** — adds a supported-NPU bullet alongside OS/toolchain
- **Run examples (Windows)** — the snippet already used `transform_aie2p.mlir` without explaining why; now says what the npu1 equivalents do
- **Windows Known Limitations** — where people look after something fails

## Notes

- Uses "not yet supported" / "currently validated" rather than making a claim about future plans.
- Refers to targets as npu1 (AIE2) / npu2 (AIE2P) rather than device code names.
- One claim worth a reviewer's confirmation: that Windows execution has in fact only been validated on npu2. That's inferred from the README's own examples and from `nightly-wheels.yml` building Windows wheels without ever running a kernel, not from a test record.

Two follow-ups are **not** in this PR:

1. `run.wait()` in the generated launcher (`driver.py:1298`) returns the `ert_cmd_state` rather than throwing, so an aborted command is silently swallowed and the output buffer is copied back anyway. That's why #88 presented as a numerical mismatch instead of a dispatch error — and it affects Linux equally. Worth a separate fix.
2. A Windows warning at npu-version resolution, so the limitation reaches users who already have an environment set up and won't re-read the README.

Refs #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)