### PR TITLE
Surface aborted npu1 kernel commands instead of returning zeroed buffers

### DIFF
--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -1316,6 +1316,8 @@ static PyObject* py_set_paths(PyObject* self, PyObject* args) {{
 // Call to XRT goes here:
 static void _launch(int gridX, int gridY, int gridZ, {', '.join(f"long size{i}" for i, ty in signature.items() if i not in constants and ty[0]=="*")}, {arg_decls}) {{
   if (gridX*gridY*gridZ > 0) {{
+    try {{
+
     // PDI artifacts target an alternative (non-XRT) runtime and cannot be
     // loaded through the XRT xclbin API below. Fail early with a clear
     // message pointing the user to their target runtime.
@@ -1410,7 +1412,9 @@ static void _launch(int gridX, int gridY, int gridZ, {', '.join(f"long size{i}" 
     unsigned int opcode = 3;
     {'auto start = std::chrono::high_resolution_clock::now();' if autotune_time else ''}
     auto run = kernel(opcode, bo_instr, instr_v.size(), {','.join(f'bo_{i}' for i, ty in signature.items() if i not in constants and ty[0] == "*")});
-    run.wait();
+    // Throws unless the command reaches ERT_CMD_STATE_COMPLETED; an aborted run
+    // must not fall through to the readback below and return zeros as a result.
+    run.wait2();
     {'auto stop = std::chrono::high_resolution_clock::now(); float npu_time = std::chrono::duration_cast<std::chrono::microseconds>(stop - start).count();' if autotune_time else ''}
 
     {'std::ofstream file("data.txt"); file << npu_time << std::endl; file.close();' if autotune_time else ''}
@@ -1423,6 +1427,11 @@ static void _launch(int gridX, int gridY, int gridZ, {', '.join(f"long size{i}" 
 
     if (verbosity >= 1)
         std::cout << "Launch finished." << std::endl;
+
+    }} catch (const std::exception& e) {{
+        std::string msg = std::string("XRT runtime error: ") + e.what();
+        PyErr_SetString(PyExc_RuntimeError, msg.c_str());
+    }}
   }}
 }}
 


### PR DESCRIPTION
## Problem

The xclbin launcher (npu1 / AIE2) called `run.wait()`, which *returns* the `ert_cmd_state` rather than throwing. The return value was discarded, so a command ending in `ERT_CMD_STATE_ABORT` or `ERT_CMD_STATE_TIMEOUT` fell straight through to the readback and copied out an untouched output buffer. A dispatch-layer failure therefore presented as silently wrong numbers.

This was asymmetric. The ELF launcher (npu2) already used `wait2()` inside a `try`/`catch`, so npu2 users have been getting proper Python exceptions all along — only the npu1 xclbin path failed silently, which is part of why it went unnoticed.

## Changes

- `run.wait()` → `run.wait2()`. Verified against XRT `main`: both funnel into the same `run_impl` (`handle->wait()` vs `handle->wait_throw_on_error()`), and the no-arg `wait2()` forwards to `wait2(0ms)`, which blocks until completion exactly as the no-arg `wait()` does. No timeout is introduced, so long-running kernels and autotuning sweeps are unaffected. The only difference is that a non-`COMPLETED` state throws `xrt::run::command_error`.
- Wrap `_launch` in the same `try` / `catch (const std::exception&)` → `PyErr_SetString` the ELF launcher uses. `command_error` derives from `std::exception`, so it is caught and reported as a Python `RuntimeError`.

The try/catch also fixes two **pre-existing crash paths**: the PDI guard and the instruction-file reads already threw `std::runtime_error` with no handler in this launcher, so those exceptions propagated through the CPython C API boundary and terminated the interpreter rather than raising. Anyone hitting the PDI guard got a hard abort instead of the helpful message written for it.

## Scope of the audit

Every dispatch path in the tree was checked; this was the only one missing the check:

| Path | Site | Status |
|---|---|---|
| XRT xclbin (npu1) | `driver.py` | `run.wait()` — **fixed here** |
| XRT ELF (npu2) | `driver.py` | already `wait2()` + try/catch |
| pyxrt multilaunch | `multilaunch.py` | already `run.wait2()` |
| HSA / ROCR (npu1) | `HsaRuntime.cpp` | already checks the completion signal and throws |

## Testing

npu1 (Phoenix, XRT 2.23.0), full examples suite via `scripts/run_tests.py --device aie2`.

Note for anyone reproducing this: the on-disk cache key is built from `str(air_output)` plus format/link/npu/bf16 flags and **does not include the launcher source**, so swapping `driver.py` between variants does not invalidate the cached `__npu_dispatch.so`. The Triton cache must be cleared between variants or the A/B is meaningless. (Arguably worth fixing separately.)

Cold-cache full suite: HEAD 12 pass / 5 fail, patched 10 pass / 7 fail. The two deltas — `matmul_bf16_m64_n64_k64` and `test_layernorm` — were then run 3× per variant in isolation and **pass 3/3 under both**, so they are order-dependent flakes, not regressions. The elementwise examples (relu/sigmoid/silu) were likewise run 2 rounds × 2 variants: results varied by round but were identical between HEAD and patched in every cell.

The 5 baseline failures are pre-existing and all fail during aircc compilation, before any launcher code runs: `matmul_f32_m64_n32_k16_padded_atransposed` and `weighted_rms_norm`, plus three untracked local scratch files in the working tree.

## Relationship to #88

This is **not** a fix for the Windows npu1 abort reported there — that is a driver-side issue. It is why the abort was invisible: the reporter saw a 99.4% tensor mismatch from Python and could only recover the real error (`ERT_CMD_STATE_ABORT state=6`) by writing a standalone C++ repro that called `wait2()`. With this change that error reaches Python directly.

The silent-readback bug is not Windows-specific — any aborted or timed-out npu1 command on Linux produces silently wrong results today.

Refs #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)