### PR TITLE
Bump mlir-air pin to 778c937 (mlir-aie 1.4.1.dev58+gf501f21)

### DIFF
--- a/utils/mlir-air-hash.txt
+++ b/utils/mlir-air-hash.txt
@@ -1,3 +1,3 @@
-Commit: 85f638d
-Timestamp: 2026080804
+Commit: 778c937
+Timestamp: 2026081120
 Version: 0.0.1


### PR DESCRIPTION
Picks up the mlir-air wheel published 2026-08-11 (`0.0.1.2026081120+778c937.no.rtti`).

The headline change in the range is mlir-air's own *Bump mlir-aie to 1.4.1.dev58+gf501f21* (#1782), so this moves the whole pinned MLIR-AIE/AIR stack forward. The range also carries one compiler change, `mlir/lib/Conversion/AIRToAIEPass.cpp` (+3/-3), alongside `programming_examples` updates that don't affect us.

`setup.py` derives the `mlir-air[aie]` requirement from `utils/mlir-air-hash.txt`, so this one file is the whole change.

## Resulting stack

| package | before | after |
| --- | --- | --- |
| mlir-air | 0.0.1.2026080804+85f638d | 0.0.1.2026081120+778c937 |
| mlir-aie-no-rtti | 1.4.1.dev46+g687ff97 | 1.4.1.dev58+gf501f21 |
| llvm-aie | 21.0.0.2026073101+cfd8aae2 | 21.0.0.2026080601+f4a72c27 |

llvm-aie moves too, as designed — the `[aie]` extra leaves it unpinned and `env_setup.sh` force-upgrades to nightly.

## Testing

Ran the NPU1-compatible examples on local hardware (Phoenix 7840U, XRT 2.23.0) before and after the bump. **Identical results: same passes, same failure signatures.**

- Passing: `vec-add`, `relu`, `sigmoid`, `silu`, `leaky_relu`, `axpy`, `swiglu`, `average_pool`, `test_softmax`, `test_layernorm`
- `matmul_bf16_m64_n64_k64` — passes (exit 0) when run standalone; its cold-cache aircc compile takes ~6.5 min, which just exceeded the local runner's timeout
- `matmul_f32_m64_n32_k16_padded_atransposed` and `weighted_rms_norm` — fail at aircc, but reproduce identically on the previous pin, so they are pre-existing and not fallout from this bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)