### PR TITLE
Bump mlir-air pin to d0e522b (mlir-aie 1.4.2.dev14+gc84915b)

### DIFF
--- a/utils/mlir-air-hash.txt
+++ b/utils/mlir-air-hash.txt
@@ -1,3 +1,3 @@
-Commit: 778c937
-Timestamp: 2026081120
+Commit: d0e522b
+Timestamp: 2026081604
 Version: 0.0.1


### PR DESCRIPTION
## What this does

Moves the mlir-air pin in `utils/mlir-air-hash.txt` from `778c937` to `d0e522b`. The matching mlir-aie comes along transitively through mlir-air's `[aie]` extra:

| | from | to |
| --- | --- | --- |
| mlir-air | `0.0.1.2026081120+778c937` | `0.0.1.2026081604+d0e522b` |
| mlir-aie (via `[aie]`) | `1.4.1.dev58+gf501f21` | `1.4.2.dev14+gc84915b` |

## Why now

That mlir-aie range includes [Xilinx/mlir-aie#3547](https://github.com/Xilinx/mlir-aie/pull/3547), which adds the missing `AIEVecToLLVM` lowering for `aievec.neg` on both AIE2 and AIE2p. Before it, *any* 16-lane float negate reaching the aievec pipeline died with:

```
error: failed to legalize operation 'aievec.neg' that was explicitly marked illegal
```

`ComputeNegOpPattern` produced the op and nothing could consume it — the string `NegOp` did not appear in `AIEVecToLLVM.cpp` at all.

Nothing on `main` hits this today, because the currently pinned triton still lowers `-x` to `arith.subf %cst0, %x`. Newer triton emits `arith.negf` instead, so this is a prerequisite for #95 (the triton-shared/triton bump), where it currently costs four examples on aie2p and three on aie2.

I confirmed `c84915b` actually contains the fix rather than relying on version ordering:

```
$ git merge-base --is-ancestor dd186682c c84915b && echo included
included
```

## Validation

npu1 (Phoenix, XRT 2.23.0), `scripts/run_tests.py --device aie2`, clean rebuild against the new stack with a stock `aiecc`:

**13/18 — the same five failures as before the bump**: `matmul_f32_m64_n32_k16_padded_atransposed`, `weighted_rms_norm`, and three untracked local scratch scripts. No regressions, nothing newly fixed (as expected — main's triton never emits `arith.negf`).

Note this also pulls a newer llvm-aie nightly (`22.0.0.2026081701+4a1adefa`), since `utils/env_setup.sh` always force-upgrades llvm-aie to latest. `pip check` reports it as "not supported on this platform", but that is a wheel platform-tag quirk — the toolchain runs fine (`llc --version` works, and the full suite compiles and executes on hardware through it).

I have not tested aie2p; no NPU2 hardware here. CI covers that.
