### PR TITLE
Make the Windows build and run path fail loudly instead of subtly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# The patches in third_party/ are authored with LF context lines. Git's Windows
+# default (core.autocrlf=true) would rewrite them to CRLF on checkout, and
+# `git apply` then rejects every hunk -- historically a silent no-op that only
+# surfaced ~20 minutes later as a C2397 error in PtrAnalysis.cpp. Pin them so
+# they are LF regardless of the user's git configuration.
+#
+# Note this cannot govern the submodule working trees the patches are applied
+# to; each submodule has its own attributes. scripts/patching.py handles that
+# side with --ignore-whitespace and a --3way fallback.
+third_party/*.patch text eol=lf

--- a/README.md
+++ b/README.md
@@ -197,6 +197,18 @@ now. See [#88](https://github.com/amd/Triton-XDNA/issues/88).
 
 ### Windows Quick Start
 
+Configure git for LF **before cloning**. Windows defaults to
+`core.autocrlf=true`, which rewrites the submodule working trees to CRLF; the
+patches in `third_party/` are authored with LF, so they then fail to apply.
+The build recovers from this automatically (see
+[scripts/patching.py](scripts/patching.py)), but starting from LF avoids the
+question entirely and matches what CI does:
+
+```powershell
+git config --global core.autocrlf false
+git config --global core.eol lf
+```
+
 ```powershell
 git clone https://github.com/amd/Triton-XDNA.git
 cd Triton-XDNA
@@ -206,6 +218,11 @@ python -m venv venv
 .\venv\Scripts\activate
 pip install --upgrade pip setuptools wheel
 ```
+
+Visual Studio does **not** need to be activated first — the build locates
+`vcvars64.bat` itself, so an ordinary PowerShell prompt works. Running from an
+"x64 Native Tools Command Prompt" is still fine; that environment is used as-is
+when present.
 
 Prepare XRT development files (headers, import library, xclbinutil). Download
 `xrt_windows_sdk.zip` from [Xilinx/XRT releases](https://github.com/Xilinx/XRT/releases)
@@ -299,7 +316,18 @@ successfully on Windows but do not yet execute; see the limitation noted under
 | Variable | Purpose |
 |----------|---------|
 | `AIR_TRANSFORM_TILING_SCRIPT` | Path to MLIR transform dialect IR |
-| `XILINX_XRT` | (Optional) Override XRT SDK location if not in `C:\Program Files\AMD\xrt` |
+| `XRT_DEV_DIR` | (Optional) Override XRT SDK location if not in `C:\Program Files\AMD\xrt`. **Prefer this over `XILINX_XRT`** |
+| `AMD_TRITON_NPU_XRT_DIR` | (Optional) Same, taking precedence over `XRT_DEV_DIR`; also settable as `npu_config.xrt_dir` |
+| `XILINX_XRT` | (Optional, discouraged on Windows) Also honoured, but see below |
+
+**Do not use `XILINX_XRT` on Windows unless it points at a full XRT
+installation.** `xrt_coreutil.dll` reads the same variable and then requires an
+`xrt_core.dll` that the NPU driver does not ship, so pointing it at an SDK
+extracted from `xrt_windows_sdk.zip` breaks device detection and kernel
+dispatch with `No such library '...\xrt_core.dll'`. The backend detects this
+case, warns, and unsets the variable for its own process while still using it
+to locate the development files — but `XRT_DEV_DIR` avoids the problem
+outright.
 
 ### Windows Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This is an experimental project and we welcome community contributions. Whether 
 
 ## Usage
 
+The instructions below are for Linux. For Windows, skip to
+[Windows Support](#windows-support).
+
 ### Clone the repository
 ```
 git clone https://github.com/amd/Triton-XDNA.git
@@ -173,43 +176,96 @@ system ROCR without AIE support would otherwise be picked up first.
 
 ## Windows Support
 
-Native Windows builds are supported using MSVC — no WSL or Linux required. The full
-compilation pipeline (Triton → MLIR → xclbin/ELF) runs natively on Windows.
+Triton-XDNA runs natively on Windows — no WSL, no Linux VM. The whole flow,
+from `@triton.jit` through MLIR to an NPU binary and kernel dispatch, executes
+on the Windows host using MSVC.
 
-**Kernel execution on Windows is currently validated on npu2 (AIE2P) devices only.**
-On npu1 (AIE2) the compile pipeline completes, but dispatch goes through the older
-xclbin/DPU path, which is not yet supported on the Windows NPU driver stack; kernels
-abort with `ERT_CMD_STATE_ABORT` and produce zeroed output. Use Linux for npu1 for
-now. See [#88](https://github.com/amd/Triton-XDNA/issues/88).
+Kernel execution is validated on **npu2 (AIE2P)** devices. Compilation itself
+needs no NPU at all, so any Windows machine can build and cross-compile
+artifacts.
 
-### Windows Requirements
+### Requirements
 
-- **Windows 10/11** (x64)
-- **AMD NPU: npu2 (AIE2P)** to *run* kernels. Building and compiling work on any
-  Windows host (no NPU required); npu1 (AIE2) can compile but not yet execute
-- **Visual Studio 2022** with "Desktop development with C++" workload
-- **Python 3.10–3.14** (3.13 recommended). Prebuilt Windows wheels are published
-  for all of these versions; 3.13 is recommended because it matches the prebuilt
-  `pyxrt.pyd` in the current XRT Windows SDK (see below), so the runtime binding
-  works without building it from source.
-- **CMake 3.20+** and **Ninja** (via pip or standalone)
-- **AMD NPU driver** (installs `xrt_coreutil.dll` runtime)
+| | |
+|---|---|
+| OS | Windows 10 or 11 (x64) |
+| NPU | npu2 (AIE2P) to run kernels; none required to compile |
+| Python | 3.11–3.14 (3.13 recommended — see [Set up XRT](#set-up-xrt)) |
+| Compiler | Visual Studio 2022 or newer, with "Desktop development with C++" |
+| Driver | AMD NPU driver |
 
-### Windows Quick Start
+Visual Studio does not need to be activated first — Triton-XDNA locates
+`vcvars64.bat` on its own, so an ordinary PowerShell prompt is enough. Running
+from an "x64 Native Tools Command Prompt" also works; that environment is used
+as-is when present.
 
-Configure git for LF **before cloning**. Windows defaults to
-`core.autocrlf=true`, which rewrites the submodule working trees to CRLF; the
-patches in `third_party/` are authored with LF, so they then fail to apply.
-The build recovers from this automatically (see
-[scripts/patching.py](scripts/patching.py)), but starting from LF avoids the
-question entirely and matches what CI does:
+For the NPU driver itself, follow the
+[mlir-aie instructions](https://github.com/Xilinx/mlir-aie/blob/main/README.md).
+
+### Set up XRT
+
+Triton-XDNA compiles a small host shim for every kernel, so it needs the XRT
+SDK (headers and import library) in addition to the runtime DLL the driver
+installs.
+
+Download `xrt_windows_sdk.zip` from the
+[Xilinx/XRT releases](https://github.com/Xilinx/XRT/releases) page and extract
+the inner `xrt_sdk/xrt/` directory — note the zip's top-level folder is
+`xrt_sdk/` — to `C:\Program Files\AMD\xrt`, so that you have:
+
+```
+C:\Program Files\AMD\xrt\include\xrt\xrt_bo.h
+C:\Program Files\AMD\xrt\lib\xrt_coreutil.lib
+```
+
+To keep it somewhere else, point `XRT_DEV_DIR` at that directory instead:
+
+```powershell
+$env:XRT_DEV_DIR = "<path-to>\xrt"
+```
+
+The same zip ships the Python binding `pyxrt.pyd` at
+`xrt_sdk/xrt/python/pyxrt.pyd`, which is used to identify the NPU. Copy it onto
+your interpreter's import path:
+
+```powershell
+Copy-Item "<path-to>\xrt_sdk\xrt\python\pyxrt.pyd" ".\venv\Lib\site-packages\"
+```
+
+The published `pyxrt.pyd` targets Python 3.13, which is why that version is
+recommended — on 3.13 it works as shipped. On other versions, build `pyxrt`
+from source against your interpreter.
+
+### Option 1: Install Pre-built Wheel (Recommended)
+
+Windows wheels are published for every supported Python version, so no compiler
+or source build is involved:
+
+```powershell
+python -m venv venv
+.\venv\Scripts\activate
+python -m pip install --upgrade pip
+
+pip install triton-xdna `
+  --find-links https://github.com/amd/Triton-XDNA/releases/expanded_assets/latest-wheels `
+  --find-links https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 `
+  --find-links https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly `
+  --find-links https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti
+
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+```
+
+PyTorch is used by the examples as a CPU reference.
+
+### Option 2: Build from Source
+
+Check the sources out with LF line endings, which is what the vendored
+submodules expect:
 
 ```powershell
 git config --global core.autocrlf false
 git config --global core.eol lf
-```
 
-```powershell
 git clone https://github.com/amd/Triton-XDNA.git
 cd Triton-XDNA
 git submodule update --init
@@ -219,53 +275,16 @@ python -m venv venv
 pip install --upgrade pip setuptools wheel
 ```
 
-Visual Studio does **not** need to be activated first — the build locates
-`vcvars64.bat` itself, so an ordinary PowerShell prompt works. Running from an
-"x64 Native Tools Command Prompt" is still fine; that environment is used as-is
-when present.
-
-Prepare XRT development files (headers, import library, xclbinutil). Download
-`xrt_windows_sdk.zip` from [Xilinx/XRT releases](https://github.com/Xilinx/XRT/releases)
-and extract the inner `xrt_sdk/xrt/` directory (note the zip's top-level
-folder is `xrt_sdk/`) to `C:\Program Files\AMD\xrt`:
-
-```powershell
-# The contents of xrt_sdk/xrt/ inside the zip should end up at:
-#   C:\Program Files\AMD\xrt\include\xrt\xrt_bo.h
-#   C:\Program Files\AMD\xrt\lib\xrt_coreutil.lib
-```
-
-The same zip also contains the runtime Python binding `pyxrt.pyd` at
-`xrt_sdk/xrt/python/pyxrt.pyd`, which is required at execution time (the NPU
-launcher does `import pyxrt`). Copy it onto your interpreter's import path:
-
-```powershell
-# The current pyxrt.pyd targets Python 3.13. On a 3.13 venv, copy it into
-# site-packages (or any directory on PYTHONPATH):
-Copy-Item "path\to\xrt_sdk\xrt\python\pyxrt.pyd" ".\venv\Lib\site-packages\"
-```
-
-`pyxrt.pyd` loads `xrt_coreutil.dll` at import time, so ensure the AMD NPU driver
-is installed (it provides that DLL) and on `PATH`. On a Python version other than
-the one the `.pyd` targets, importing it raises `ImportError: DLL load failed`;
-in that case, build `pyxrt` from source against your interpreter.
-
-Run the automated environment setup (must be dot-sourced so PATH/env vars
-persist in the current shell):
+Then run the environment setup, which installs the MLIR-AIE/AIR/LLVM-AIE stack
+and the Triton-XDNA backend. Dot-source it so the environment persists in your
+shell:
 
 ```powershell
 . .\utils\env_setup.ps1
 ```
 
-This installs the pre-built wheels (`triton-windows`, `mlir-air[aie]` which
-transitively pulls `mlir-aie` and `llvm-aie`) and the Triton-XDNA backend.
-
-### Windows Manual Build
-
-Install build tools, PyTorch, and the MLIR-AIE/AIR/LLVM-AIE stack. The
-`mlir_air[aie]` extra transitively pins matching `mlir-aie` and pulls
-`llvm-aie`, so a single resolver pass installs the whole stack from the
-Xilinx release pages:
+To drive the install yourself instead, the `mlir_air[aie]` extra pins a matching
+`mlir-aie` and pulls `llvm-aie`, so one resolver pass installs the whole stack:
 
 ```powershell
 pip install cmake ninja lit numpy PyYAML nanobind scipy
@@ -275,30 +294,18 @@ pip install "mlir_air[aie]" `
   -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti `
   -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 `
   -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+
+pip install . --no-build-isolation
 ```
 
 To pin a specific mlir-air version, use the values from
 `utils/mlir-air-hash.txt`:
 `mlir_air[aie]==<Version>.<Timestamp>+<short-commit>.no.rtti`.
 
-Install Triton-XDNA:
+### Run examples
 
-```powershell
-$env:TRITON_PLUGIN_DIRS = "$PWD\third_party\triton_shared;$PWD\amd_triton_npu"
-pip install -e . --no-build-isolation -v
-```
-
-### Additional Windows Tools
-
-**xclbinutil** and **aiebu-asm** — Included in the XRT Windows SDK zip. Ensure they
-are on PATH or in `<mlir_aie_install>/bin/`.
-
-**DIA SDK** — If the mlir-air cmake build can't find DIA SDK:
-```powershell
-subst Z: "C:\Program Files\Microsoft Visual Studio\2022\Community\DIA SDK"
-```
-
-### Run examples (Windows)
+Browse the available operators and their AIE2/AIE2P coverage in the live
+[examples dashboard](https://amd.github.io/Triton-XDNA/).
 
 ```powershell
 cd examples\vec-add
@@ -306,40 +313,62 @@ $env:AIR_TRANSFORM_TILING_SCRIPT = "transform_aie2p.mlir"
 python vec-add.py
 ```
 
-`transform_aie2p.mlir` targets npu2 (AIE2P). The npu1 (AIE2) equivalents —
-`transform_aie2.mlir` with `$env:AMD_TRITON_NPU_TARGET = "npu1"` — compile
-successfully on Windows but do not yet execute; see the limitation noted under
-[Windows Support](#windows-support).
+Examples check their results against PyTorch and raise on mismatch, so a clean
+exit with no output means the kernel ran correctly on the NPU. The compiled
+artifacts and intermediate IR are left in `air_project\` next to the example.
+
+To run the whole suite:
+
+```powershell
+python scripts\run_tests.py --device aie2p
+```
+
+`transform_aie2p.mlir` targets npu2 (AIE2P); `transform_aie2.mlir` targets npu1
+(AIE2).
+
+Compilation does not require matching hardware. Setting
+`AMD_TRITON_NPU_TARGET` selects the device to compile for and
+`AMD_TRITON_NPU_COMPILE_ONLY=1` stops before dispatch, so any Windows machine
+can produce artifacts for either generation — they are written to
+`air_project\`. Note that the examples verify their results against PyTorch, so
+they are meant to be run with dispatch enabled; use compile-only when you want
+the artifacts rather than a pass/fail result.
 
 ### Windows Environment Variables
 
 | Variable | Purpose |
 |----------|---------|
-| `AIR_TRANSFORM_TILING_SCRIPT` | Path to MLIR transform dialect IR |
-| `XRT_DEV_DIR` | (Optional) Override XRT SDK location if not in `C:\Program Files\AMD\xrt`. **Prefer this over `XILINX_XRT`** |
-| `AMD_TRITON_NPU_XRT_DIR` | (Optional) Same, taking precedence over `XRT_DEV_DIR`; also settable as `npu_config.xrt_dir` |
-| `XILINX_XRT` | (Optional, discouraged on Windows) Also honoured, but see below |
+| `AIR_TRANSFORM_TILING_SCRIPT` | Path to the MLIR transform dialect tiling script |
+| `XRT_DEV_DIR` | XRT SDK location, if not at `C:\Program Files\AMD\xrt` |
+| `AMD_TRITON_NPU_XRT_DIR` | Same, taking precedence over `XRT_DEV_DIR`; also settable as `npu_config.xrt_dir` |
+| `AMD_TRITON_NPU_TARGET` | Force `npu1` or `npu2` instead of detecting the installed device |
+| `AMD_TRITON_NPU_COMPILE_ONLY` | `1` to compile without dispatching — build on a machine with no NPU |
+| `AMD_TRITON_NPU_OUTPUT_FORMAT` | Force `elf` or `xclbin`; defaults to `elf` on npu2, `xclbin` on npu1 |
+| `AMD_TRITON_NPU_BF16_EMULATION` | `1` to truncate f32 to bf16 before multiply, accumulating in f32 |
+| `AMD_TRITON_NPU_AIR_PROJECT_PATH` | Where intermediate IR and artifacts are written (default `.\air_project`) |
+| `AMD_TRITON_NPU_DEBUG` | `1` for verbose compiler and launcher output |
 
-**Do not use `XILINX_XRT` on Windows unless it points at a full XRT
-installation.** `xrt_coreutil.dll` reads the same variable and then requires an
-`xrt_core.dll` that the NPU driver does not ship, so pointing it at an SDK
-extracted from `xrt_windows_sdk.zip` breaks device detection and kernel
-dispatch with `No such library '...\xrt_core.dll'`. The backend detects this
-case, warns, and unsets the variable for its own process while still using it
-to locate the development files — but `XRT_DEV_DIR` avoids the problem
-outright.
+Each of these is also settable from Python via `npu_config` — see
+`amd_triton_npu/backend/config.py`. The HSA runtime (`AMD_TRITON_NPU_RUNTIME`)
+is Linux-only.
 
-### Windows Known Limitations
+### Troubleshooting
 
-- Kernel execution is currently validated on npu2 (AIE2P) only. npu1 (AIE2)
-  compiles but does not yet execute on Windows — dispatch uses the xclbin/DPU
-  path, which the Windows NPU driver stack does not yet support, so kernels abort
-  (`ERT_CMD_STATE_ABORT`) and outputs come back zeroed. Use Linux for npu1 for
-  now. See [#88](https://github.com/amd/Triton-XDNA/issues/88)
-- Python 3.10–3.14 supported; 3.13 recommended so the prebuilt `pyxrt.pyd` in the
-  XRT Windows SDK can be used as-is. On other versions, build `pyxrt` from source
-  to match your interpreter
-- `pyxrt.pyd` (from the XRT Windows SDK zip) must be on `PYTHONPATH` /
-  site-packages, and the AMD NPU driver's `xrt_coreutil.dll` must be on `PATH`
-- xclbinutil and aiebu-asm must be on PATH (from XRT Windows SDK)
-- NPU driver must be installed
+**`ImportError: DLL load failed` when importing `pyxrt`** — the prebuilt
+`pyxrt.pyd` targets Python 3.13. Either use a 3.13 interpreter or build `pyxrt`
+from source against the version you are running.
+
+**`pyxrt` imports but finds no device** — `pyxrt.pyd` loads `xrt_coreutil.dll`
+from the AMD NPU driver. Confirm the driver is installed and that
+`xrt-smi examine` lists the device.
+
+**"XRT development files not found"** — the XRT SDK is missing or incomplete.
+The error lists every location that was searched; extract
+`xrt_windows_sdk.zip` as described in [Set up XRT](#set-up-xrt), or point
+`XRT_DEV_DIR` at it. A runtime-only install (just the driver's DLLs) is not
+enough to compile.
+
+**npu1 (AIE2) kernels abort with `ERT_CMD_STATE_ABORT` and return zeros** —
+npu1 dispatch uses the older xclbin/DPU path, which the Windows NPU driver stack
+does not yet support. npu1 compiles on Windows but must be run on Linux; see
+[#88](https://github.com/amd/Triton-XDNA/issues/88).

--- a/amd_triton_npu/backend/config.py
+++ b/amd_triton_npu/backend/config.py
@@ -62,6 +62,7 @@ class _NPUConfig:
         self._debug = MISSING
         self._target = MISSING
         self._runtime = MISSING
+        self._xrt_dir = MISSING
 
     # ---- compile_only ----
 
@@ -267,6 +268,30 @@ class _NPUConfig:
             )
         self._runtime = value
 
+    # ---- xrt_dir ----
+
+    @property
+    def xrt_dir(self):
+        """Directory holding the XRT *development* files (``include/xrt`` + ``lib``).
+
+        Set this to point the JIT compiler at an XRT SDK in a non-standard
+        location. Prefer it over ``XILINX_XRT``: on Windows that variable is
+        also read by ``xrt_coreutil.dll``, which then insists on ``xrt_core.dll``
+        -- a file the NPU-only driver stack does not ship -- so setting it
+        breaks device detection and kernel dispatch.
+
+        Env var fallback: ``AMD_TRITON_NPU_XRT_DIR``. Set to ``None`` to fall
+        back to the normal search (``XRT_DEV_DIR``, ``XILINX_XRT``, then the
+        platform default).
+        """
+        if self._xrt_dir is not MISSING:
+            return self._xrt_dir
+        return os.getenv("AMD_TRITON_NPU_XRT_DIR") or None
+
+    @xrt_dir.setter
+    def xrt_dir(self, value):
+        self._xrt_dir = value
+
     # ---- utilities ----
 
     def reset(self):
@@ -279,6 +304,7 @@ class _NPUConfig:
         self._debug = MISSING
         self._target = MISSING
         self._runtime = MISSING
+        self._xrt_dir = MISSING
 
 
 # Module-level singleton
@@ -309,6 +335,7 @@ def set_config(**kwargs):
         "air_project_path",
         "target",
         "runtime",
+        "xrt_dir",
     }
     for key, value in kwargs.items():
         if key not in valid_keys:

--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -2013,6 +2013,30 @@ def _aircc_compile(
         ):
             os.environ["PATH"] = mlir_aie_bin + os.pathsep + os.environ.get("PATH", "")
 
+        # Same idea for the XRT SDK: aiecc shells out to aiebu-asm (and
+        # xclbinutil on the xclbin path) by bare name, and those ship in the
+        # XRT Windows SDK rather than with mlir-aie, so without help the ELF
+        # build dies with
+        #     aiecc: ShellCommand: tool 'aiebu-asm' not found in search paths
+        # We already know where the SDK is, so putting it on PATH here is
+        # strictly better than asking every user to do it by hand. Failure to
+        # locate an SDK is not fatal here -- aircc may not need it, and the
+        # launcher reports a far clearer error if it does.
+        try:
+            xrt_dir = _get_xrt_path()
+        except RuntimeError:
+            xrt_dir = None
+        if xrt_dir:
+            # xclbinutil.exe / aiebu-asm.exe sit at the SDK root; keep bin/ too
+            # for layouts that use it.
+            for tool_dir in (xrt_dir, os.path.join(xrt_dir, "bin")):
+                if os.path.isdir(tool_dir) and tool_dir not in os.environ.get(
+                    "PATH", ""
+                ):
+                    os.environ["PATH"] = (
+                        tool_dir + os.pathsep + os.environ.get("PATH", "")
+                    )
+
     if output_format == "elf":
         elf_path = os.path.join(air_proj_path, "aie.elf")
         aircc_cmd = [

--- a/amd_triton_npu/backend/driver.py
+++ b/amd_triton_npu/backend/driver.py
@@ -178,13 +178,82 @@ def _get_air_opt_path() -> str:
     return _find_mlir_air_binary(binary_name)
 
 
+# Set by _neutralize_hostile_xilinx_xrt() when it removes XILINX_XRT from the
+# environment: the value is still a perfectly good source of *development*
+# files, it just cannot be left visible to XRT's runtime loader.
+_stashed_xilinx_xrt = None
+_xrt_env_checked = False
+
+
+def _neutralize_hostile_xilinx_xrt() -> None:
+    """Remove XILINX_XRT from the environment when it would break XRT itself.
+
+    XILINX_XRT is overloaded. Triton-XDNA reads it to find development files
+    (headers + import lib), but on Windows ``xrt_coreutil.dll`` also reads it
+    and then treats the directory as a complete XRT installation, requiring
+    ``xrt_core.dll``. The Windows NPU driver stack ships only
+    ``xrt_coreutil.dll``, so pointing XILINX_XRT at an SDK extracted from
+    xrt_windows_sdk.zip makes both pyxrt device detection and kernel dispatch
+    die with::
+
+        RuntimeError: XRT runtime error: No such library '...\\xrt_core.dll'
+
+    When the directory has no xrt_core.dll, nothing can consume it as a runtime
+    anyway, so we take it out of the environment and remember it for
+    _get_xrt_path(). The user still gets their headers; XRT's loader falls back
+    to its own (working) default search.
+
+    Windows-only: on Linux XILINX_XRT is the standard way to select an XRT
+    installation and removing it would break the runtime rather than fix it.
+    Idempotent, and safe to call from several entry points.
+    """
+    global _stashed_xilinx_xrt, _xrt_env_checked
+    if _xrt_env_checked:
+        return
+    _xrt_env_checked = True
+
+    if not IS_WINDOWS:
+        return
+
+    env_path = os.environ.get("XILINX_XRT", "")
+    if not env_path:
+        return
+    if os.path.isfile(os.path.join(env_path, "xrt_core.dll")):
+        # A full XRT installation - leave it alone.
+        return
+
+    _stashed_xilinx_xrt = env_path
+    os.environ.pop("XILINX_XRT", None)
+    # warnings.warn, not logger.warning: this module's logger sits at CRITICAL
+    # unless AMD_TRITON_NPU_DEBUG=1, and quietly rewriting someone's
+    # environment deserves to be visible by default.
+    import warnings
+
+    warnings.warn(
+        f"XILINX_XRT={env_path} contains no xrt_core.dll. XRT's runtime "
+        "loader would fail on it ('No such library ...xrt_core.dll'), "
+        "breaking both device detection and kernel dispatch, so it has been "
+        "unset for this process. It is still used to locate XRT development "
+        "files. Set XRT_DEV_DIR (or npu_config.xrt_dir) instead to silence "
+        "this.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    logger.debug("Neutralized XILINX_XRT=%s (no xrt_core.dll)", env_path)
+
+
 def _get_xrt_path() -> str:
     """Get the path to the XRT development directory (headers + import lib).
 
     Search order:
-    1. XILINX_XRT environment variable (standard on both Linux and Windows)
-    2. (Windows) C:\\Program Files\\AMD\\xrt  (recommended install location)
-    3. (Linux) /opt/xilinx/xrt
+    1. ``npu_config.xrt_dir`` / ``AMD_TRITON_NPU_XRT_DIR``
+    2. ``XRT_DEV_DIR`` environment variable
+    3. ``XILINX_XRT`` environment variable
+    4. (Windows) C:\\Program Files\\AMD\\xrt  (recommended install location)
+    5. (Linux) /opt/xilinx/xrt
+
+    Prefer XRT_DEV_DIR over XILINX_XRT on Windows -- see
+    :func:`_neutralize_hostile_xilinx_xrt` for why the latter is hazardous.
 
     The returned directory must contain the SDK components (include/xrt headers
     and lib/) needed for JIT compilation.  A runtime-only installation (e.g.
@@ -193,6 +262,7 @@ def _get_xrt_path() -> str:
     On Windows, download xrt_windows_sdk.zip from the Xilinx/XRT releases page
     and extract the xrt/ directory to C:\\Program Files\\AMD\\xrt.
     """
+    _neutralize_hostile_xilinx_xrt()
 
     def _validate_xrt_sdk(path: str, source: str) -> str:
         """Ensure *path* contains the SDK components needed for compilation."""
@@ -215,28 +285,45 @@ def _get_xrt_path() -> str:
             )
         return ""  # path doesn't exist at all
 
-    env_path = os.getenv("XILINX_XRT", "")
-    if env_path:
-        result = _validate_xrt_sdk(env_path, "XILINX_XRT environment variable")
-        if result:
-            return result
-
     if IS_WINDOWS:
         program_files = os.environ.get("PROGRAMFILES", "C:\\Program Files")
         default_path = os.path.join(program_files, "AMD", "xrt")
-        result = _validate_xrt_sdk(default_path, "default location")
-        if result:
-            return result
+        default_desc = "default location (%PROGRAMFILES%\\AMD\\xrt)"
     else:
-        result = _validate_xrt_sdk("/opt/xilinx/xrt", "default location")
+        default_path = "/opt/xilinx/xrt"
+        default_desc = "default location (/opt/xilinx/xrt)"
+
+    # (path, human-readable source) in priority order. _stashed_xilinx_xrt
+    # stands in for XILINX_XRT when it had to be removed from the environment.
+    candidates = [
+        (npu_config.xrt_dir, "npu_config.xrt_dir / AMD_TRITON_NPU_XRT_DIR"),
+        (os.getenv("XRT_DEV_DIR", ""), "XRT_DEV_DIR environment variable"),
+        (
+            _stashed_xilinx_xrt or os.getenv("XILINX_XRT", ""),
+            "XILINX_XRT environment variable",
+        ),
+        (default_path, default_desc),
+    ]
+
+    tried = []
+    for path, source in candidates:
+        if not path:
+            continue
+        tried.append(f"  - {source}: {path}")
+        result = _validate_xrt_sdk(path, source)
         if result:
             return result
 
+    tried_text = "\n".join(tried) if tried else "  (no candidate locations)"
     raise RuntimeError(
-        "XRT development files not found. "
-        "Download xrt_windows_sdk.zip from https://github.com/Xilinx/XRT/releases "
-        "and extract the xrt/ directory to C:\\Program Files\\AMD\\xrt "
-        "(or set the XILINX_XRT environment variable to its location)."
+        "XRT development files not found. Download xrt_windows_sdk.zip from "
+        "https://github.com/Xilinx/XRT/releases and extract the inner xrt/ "
+        "directory (the one containing include/ and lib/) to "
+        "C:\\Program Files\\AMD\\xrt, or point XRT_DEV_DIR at it.\n"
+        "Locations tried:\n" + tried_text + "\n"
+        "Prefer XRT_DEV_DIR over XILINX_XRT on Windows: XILINX_XRT is also "
+        "read by xrt_coreutil.dll, which then requires an xrt_core.dll that "
+        "the NPU driver does not ship."
     )
 
 
@@ -588,6 +675,21 @@ def _get_msvc_env(cl_path: str) -> dict:
     if env.get("INCLUDE"):
         return env
 
+    # Prefer the environment vcvars64.bat itself produces: it is authoritative,
+    # tracks new Visual Studio and Windows SDK layouts for free, and brings
+    # along tools (rc.exe, mt.exe) that the manual derivation below omits. Fall
+    # back to that derivation when Visual Studio cannot be located this way --
+    # it is the path that has always been used here and still works.
+    try:
+        from .msvc import vcvars_env
+
+        vc_env = vcvars_env()
+    except Exception:
+        vc_env = None
+    if vc_env:
+        env.update(vc_env)
+        return env
+
     # Derive MSVC paths from cl.exe location:
     #   .../VC/Tools/MSVC/<ver>/bin/Hostx64/x64/cl.exe
     cl_dir = os.path.dirname(cl_path)  # .../bin/Hostx64/x64
@@ -748,6 +850,12 @@ def _pyxrt_device_name() -> str:
     come up empty on a host whose sysfs entries it cannot render even though
     the device node itself opens fine.
     """
+    # Must run before the first pyxrt call: a hostile XILINX_XRT makes
+    # pyxrt.device(0) fail outright. NPULauncher reaches device detection
+    # before it ever reaches _get_xrt_path, so this cannot be left to the
+    # latter.
+    _neutralize_hostile_xilinx_xrt()
+
     import pyxrt
 
     device = pyxrt.device(0)
@@ -2548,6 +2656,9 @@ class NPUDriver(DriverBase):
             )
         # Exposed for introspection (e.g. triton.runtime.driver.active.runtime).
         self.runtime = runtime
+        # Do this once, up front, so every later XRT consumer in the process
+        # sees a sane environment (see _neutralize_hostile_xilinx_xrt).
+        _neutralize_hostile_xilinx_xrt()
         self.utils = NPUUtils()
         # Triton instantiates the launcher as ``launcher_cls(src, metadata)`` and
         # never passes the driver, so bind the chosen runtime here.

--- a/amd_triton_npu/backend/msvc.py
+++ b/amd_triton_npu/backend/msvc.py
@@ -118,9 +118,18 @@ def vcvars_env():
 
     env = {}
     for line in out.split(_ENV_MARKER, 1)[1].splitlines():
-        if "=" in line:
+        # `set` also dumps cmd's per-drive current-directory pseudo-variables,
+        # which look like "=C:=C:\some\dir" (and "=ExitCode=00000000"). Naive
+        # splitting turns those into an entry with an empty key, and passing an
+        # environment with an empty key to subprocess fails on Windows with
+        # "OSError: [WinError 87] The parameter is incorrect" -- a long way from
+        # anything that would point back to here. They carry no build state, so
+        # drop them.
+        if not line.startswith("=") and "=" in line:
             key, value = line.split("=", 1)
-            env[key.strip()] = value
+            key = key.strip()
+            if key:
+                env[key] = value
     # A vcvars environment without INCLUDE did not actually initialise.
     return env if env.get("INCLUDE") else None
 

--- a/amd_triton_npu/backend/msvc.py
+++ b/amd_triton_npu/backend/msvc.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Locate MSVC and reproduce a developer-prompt environment.
+
+Used from two places that both need a working ``cl.exe``:
+
+* ``setup.py``, to build triton-windows. It loads this module by path
+  (importlib) rather than importing it, so nothing here may import triton.
+* ``driver.py``, to JIT-compile the NPU dispatch shim at kernel launch.
+
+Both previously assumed the caller had already run ``vcvars64.bat``; outside
+such a shell the build failed with a CMake message about the ``CXX``
+environment variable that never mentioned Visual Studio. Rather than
+hand-assembling INCLUDE/LIB -- which is easy to get subtly wrong, and misses
+tools like ``rc.exe`` and ``mt.exe`` that the LLVM build needs -- we run the
+real ``vcvars64.bat`` and capture the environment it produces.
+
+Only the standard library is used, and every entry point returns ``None``
+rather than raising, so callers can fall back.
+"""
+
+import functools
+import os
+import shutil
+import subprocess
+import sys
+
+IS_WINDOWS = sys.platform == "win32"
+
+# Component id for the x64 C++ toolset. Asking vswhere to require it avoids
+# selecting a Visual Studio install that has no C++ workload.
+_VC_TOOLS_COMPONENT = "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+
+# Printed between vcvars' own chatter and the `set` dump so we can tell the
+# two apart. vcvars writes a banner to stdout and offers no quiet flag; a
+# redirect would be simpler but is awkward to quote portably through cmd.
+_ENV_MARKER = "__TRITON_XDNA_ENV_BEGIN__"
+
+
+def find_vswhere():
+    """Path to vswhere.exe, or None. It ships with VS 2017+ at a fixed location."""
+    if not IS_WINDOWS:
+        return None
+    program_files_x86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    vswhere = os.path.join(
+        program_files_x86, "Microsoft Visual Studio", "Installer", "vswhere.exe"
+    )
+    return vswhere if os.path.isfile(vswhere) else None
+
+
+@functools.lru_cache(maxsize=1)
+def find_vs_install():
+    """Installation root of the newest VS with the x64 C++ toolset, or None.
+
+    Deliberately not pinned to a Visual Studio year: ``-latest`` picks up
+    VS 2022 and VS 18 alike.
+    """
+    vswhere = find_vswhere()
+    if vswhere is None:
+        return None
+    try:
+        out = subprocess.check_output(
+            [
+                vswhere,
+                "-latest",
+                "-products",
+                "*",
+                "-requires",
+                _VC_TOOLS_COMPONENT,
+                "-property",
+                "installationPath",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    lines = [ln.strip() for ln in out.splitlines() if ln.strip()]
+    return lines[0] if lines else None
+
+
+@functools.lru_cache(maxsize=1)
+def find_vcvars():
+    """Path to vcvars64.bat for the newest suitable VS install, or None."""
+    vs_path = find_vs_install()
+    if vs_path is None:
+        return None
+    vcvars = os.path.join(vs_path, "VC", "Auxiliary", "Build", "vcvars64.bat")
+    return vcvars if os.path.isfile(vcvars) else None
+
+
+@functools.lru_cache(maxsize=1)
+def vcvars_env():
+    """Environment produced by vcvars64.bat as a dict, or None.
+
+    Spawning cmd is not cheap, so the result is cached for the process.
+    """
+    vcvars = find_vcvars()
+    if vcvars is None:
+        return None
+    # shell=True and a single command string: passing the quoted .bat path as a
+    # list element makes subprocess escape the quotes for cmd, which then
+    # cannot find the file.
+    command = f'"{vcvars}" && echo {_ENV_MARKER} && set'
+    try:
+        out = subprocess.check_output(
+            command,
+            shell=True,
+            text=True,
+            errors="replace",
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    if _ENV_MARKER not in out:
+        return None
+
+    env = {}
+    for line in out.split(_ENV_MARKER, 1)[1].splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            env[key.strip()] = value
+    # A vcvars environment without INCLUDE did not actually initialise.
+    return env if env.get("INCLUDE") else None
+
+
+def in_developer_environment():
+    """True if the current process already looks like a VS developer prompt."""
+    return bool(os.environ.get("INCLUDE"))
+
+
+def find_cl(env=None):
+    """Absolute path to cl.exe, or None.
+
+    Looks on the current PATH first (already inside a developer prompt), then
+    in *env* if given, then in a freshly captured vcvars environment.
+    """
+    if not IS_WINDOWS:
+        return None
+
+    on_path = shutil.which("cl.exe") or shutil.which("cl")
+    if on_path:
+        return on_path
+
+    for candidate_env in (env, vcvars_env()):
+        if candidate_env:
+            found = shutil.which("cl.exe", path=candidate_env.get("PATH", ""))
+            if found:
+                return found
+    return None
+
+
+SETUP_HINT = (
+    "Visual Studio with the C++ toolset was not found. Triton-XDNA needs MSVC "
+    "to compile NPU dispatch code.\n"
+    "Options:\n"
+    "  1. Install Visual Studio with the 'Desktop development with C++' "
+    "workload (https://visualstudio.microsoft.com/)\n"
+    "  2. Install the Build Tools for Visual Studio "
+    "(https://visualstudio.microsoft.com/visual-cpp-build-tools/)\n"
+    "  3. Run from an 'x64 Native Tools Command Prompt' so vcvars64.bat has "
+    "already been applied"
+)

--- a/scripts/apply_patches.py
+++ b/scripts/apply_patches.py
@@ -1,217 +1,30 @@
 #!/usr/bin/env python3
-# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+# SPDX-FileCopyrightText: Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
 """
 Apply local patches to third-party submodules before building.
 
-This script applies patch files from third_party/ to their respective submodules.
-It uses marker files to track whether patches have been applied to avoid
-re-applying them on subsequent builds.
+Thin CLI over scripts/patching.py, which holds the actual implementation and is
+shared with setup.py so the two cannot drift apart again.
 
 Usage:
-    python scripts/apply_patches.py [--reset] [--force]
+    python scripts/apply_patches.py [--reset] [--force] [--reset-only]
 
 Options:
-    --reset    Reset submodules to clean state before applying patches
-    --force    Force re-apply patches even if marker exists
+    --reset       Reset submodules to clean state before applying patches
+    --force       Force re-apply patches even if marker exists
+    --reset-only  Only reset submodules, don't apply patches
 """
 
 import argparse
-import subprocess
 import sys
 from pathlib import Path
 
-# Base directory (project root)
-BASE_DIR = Path(__file__).parent.parent.resolve()
-THIRD_PARTY_DIR = BASE_DIR / "third_party"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-# Patch configuration: (submodule_name, patch_file)
-PATCHES = [
-    ("triton", "triton.patch"),
-    ("triton_shared", "triton_shared.patch"),
-]
-
-# Marker file name to track if patches have been applied
-MARKER_FILE = ".patches_applied"
-
-
-def run_git(args: list, cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
-    """Run a git command in the specified directory."""
-    cmd = ["git"] + args
-    return subprocess.run(
-        cmd,
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        check=check,
-    )
-
-
-def reset_submodule(submodule_dir: Path) -> bool:
-    """Reset a submodule to its clean state."""
-    print(f"  Resetting {submodule_dir.name}...", file=sys.stderr)
-
-    try:
-        # Discard all local changes
-        run_git(["checkout", "."], cwd=submodule_dir)
-        # Remove untracked files
-        run_git(["clean", "-fd"], cwd=submodule_dir)
-
-        # Remove marker file if it exists
-        marker = submodule_dir / MARKER_FILE
-        if marker.exists():
-            marker.unlink()
-
-        print(f"  ✓ Reset {submodule_dir.name}", file=sys.stderr)
-        return True
-    except subprocess.CalledProcessError as e:
-        print(f"  ✗ Failed to reset {submodule_dir.name}: {e.stderr}", file=sys.stderr)
-        return False
-
-
-def check_patch_applicable(patch_file: Path, target_dir: Path) -> tuple[bool, str]:
-    """
-    Check if a patch can be applied.
-
-    Returns:
-        (can_apply, reason) tuple
-    """
-    # --ignore-whitespace tolerates CRLF/LF differences in context lines,
-    # which matters on Windows where git checkout converts text files to
-    # CRLF by default but our patches were generated with LF.
-    result = run_git(
-        ["apply", "--check", "--ignore-whitespace", str(patch_file)],
-        cwd=target_dir,
-        check=False,
-    )
-
-    if result.returncode == 0:
-        return True, "Patch can be applied"
-
-    # Check if patch is already applied by trying reverse
-    result_reverse = run_git(
-        ["apply", "--check", "--reverse", "--ignore-whitespace", str(patch_file)],
-        cwd=target_dir,
-        check=False,
-    )
-
-    if result_reverse.returncode == 0:
-        return False, "Patch already applied"
-
-    return False, f"Patch conflict: {result.stderr.strip()}"
-
-
-def apply_patch(patch_file: Path, target_dir: Path) -> bool:
-    """Apply a patch file to the target directory."""
-    try:
-        run_git(["apply", "--ignore-whitespace", str(patch_file)], cwd=target_dir)
-        return True
-    except subprocess.CalledProcessError as e:
-        print(f"  ✗ Failed to apply patch: {e.stderr}", file=sys.stderr)
-        return False
-
-
-def apply_patches(force: bool = False, reset: bool = False) -> bool:
-    """
-    Apply all configured patches to their submodules.
-
-    Args:
-        force: Force re-apply patches even if marker exists
-        reset: Reset submodules before applying patches
-
-    Returns:
-        True if all patches were applied successfully, False otherwise
-    """
-    print("=" * 60, file=sys.stderr)
-    print("Applying patches to submodules", file=sys.stderr)
-    print("=" * 60, file=sys.stderr)
-
-    all_success = True
-
-    for submodule_name, patch_name in PATCHES:
-        submodule_dir = THIRD_PARTY_DIR / submodule_name
-        patch_file = THIRD_PARTY_DIR / patch_name
-        marker_file = submodule_dir / MARKER_FILE
-
-        print(f"\n[{submodule_name}]", file=sys.stderr)
-
-        # Check if submodule directory exists
-        if not submodule_dir.exists():
-            print(
-                f"  ⚠ Submodule directory not found: {submodule_dir}", file=sys.stderr
-            )
-            continue
-
-        # Check if patch file exists
-        if not patch_file.exists():
-            print(f"  ⚠ Patch file not found: {patch_file}", file=sys.stderr)
-            continue
-
-        # Reset if requested
-        if reset:
-            if not reset_submodule(submodule_dir):
-                all_success = False
-                continue
-
-        # Check if already applied (marker exists)
-        if marker_file.exists() and not force:
-            print(f"  ✓ Patches already applied (marker exists)", file=sys.stderr)
-            continue
-
-        # Check if patch can be applied
-        can_apply, reason = check_patch_applicable(patch_file, submodule_dir)
-
-        if not can_apply:
-            if "already applied" in reason.lower():
-                print(f"  ✓ {reason}", file=sys.stderr)
-                # Create marker file
-                marker_file.touch()
-            else:
-                print(f"  ✗ {reason}", file=sys.stderr)
-                all_success = False
-            continue
-
-        # Apply the patch
-        print(f"  Applying {patch_name}...", file=sys.stderr)
-        if apply_patch(patch_file, submodule_dir):
-            print(f"  ✓ Patch applied successfully", file=sys.stderr)
-            # Create marker file
-            marker_file.touch()
-        else:
-            all_success = False
-
-    print("\n" + "=" * 60, file=sys.stderr)
-    if all_success:
-        print("All patches applied successfully!", file=sys.stderr)
-    else:
-        print("Some patches failed to apply.", file=sys.stderr)
-    print("=" * 60, file=sys.stderr)
-
-    return all_success
-
-
-def reset_all_submodules() -> bool:
-    """Reset all configured submodules to clean state."""
-    print("=" * 60, file=sys.stderr)
-    print("Resetting submodules to clean state", file=sys.stderr)
-    print("=" * 60, file=sys.stderr)
-
-    all_success = True
-
-    for submodule_name, _ in PATCHES:
-        submodule_dir = THIRD_PARTY_DIR / submodule_name
-
-        if not submodule_dir.exists():
-            print(
-                f"  ⚠ Submodule directory not found: {submodule_dir}", file=sys.stderr
-            )
-            continue
-
-        if not reset_submodule(submodule_dir):
-            all_success = False
-
-    return all_success
+from patching import PatchError, apply_patches, reset_all_submodules
 
 
 def main():
@@ -237,12 +50,15 @@ def main():
     args = parser.parse_args()
 
     if args.reset_only:
-        success = reset_all_submodules()
-    else:
-        success = apply_patches(force=args.force, reset=args.reset)
+        return 0 if reset_all_submodules() else 1
 
-    sys.exit(0 if success else 1)
+    try:
+        apply_patches(force=args.force, reset=args.reset)
+    except PatchError as e:
+        print(f"\nERROR: {e}", file=sys.stderr)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/patching.py
+++ b/scripts/patching.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Apply the local patches in third_party/ to their submodules.
+
+This is the single implementation, shared by ``setup.py`` (build time) and
+``scripts/apply_patches.py`` (the standalone CLI). It previously existed as two
+near-identical copies that had drifted apart in two ways that both broke
+Windows: only one passed ``--ignore-whitespace``, and only the other knew that
+Windows builds ``triton-windows`` rather than ``triton``.
+
+Line endings are the crux. The patches are authored with LF, but git's Windows
+default ``core.autocrlf=true`` rewrites both the patch files and the submodule
+working trees to CRLF on checkout, and a CRLF/LF mismatch on either side makes
+``git apply`` reject the hunks. Three defences, in order:
+
+1. ``.gitattributes`` pins ``third_party/*.patch`` to LF, so the patch side is
+   fixed no matter how the user has git configured. It cannot help the
+   submodule side -- attributes do not cross into a submodule's own checkout.
+2. ``--ignore-whitespace``, which tolerates EOL differences in context lines.
+3. ``--3way``, which matches on the blob SHAs recorded in the patch's ``index``
+   lines instead of on textual context, and so survives both EOL differences
+   and modest context drift.
+
+A patch that still will not apply raises :class:`PatchError`. It must not be
+skipped: an unpatched triton_shared builds for roughly twenty minutes and then
+fails with a C2397 narrowing-conversion error in ``PtrAnalysis.cpp`` that the
+patch exists to prevent, which is a miserable way to learn that patching was
+silently a no-op.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+THIRD_PARTY_DIR = BASE_DIR / "third_party"
+
+IS_WINDOWS = sys.platform == "win32"
+
+# Marker file dropped in a submodule once its patch is applied, so repeated
+# builds do not re-run the patch machinery.
+MARKER_FILE = ".patches_applied"
+
+# (submodule directory, patch file). Windows builds triton-windows instead of
+# triton -- keep this in step with TRITON_SOURCE_DIR in setup.py.
+PATCHES = [
+    (
+        ("triton-windows", "triton-windows.patch")
+        if IS_WINDOWS
+        else ("triton", "triton.patch")
+    ),
+    ("triton_shared", "triton_shared.patch"),
+]
+
+
+class PatchError(RuntimeError):
+    """A patch could not be applied and the build must not continue."""
+
+
+def _git(args, cwd, check=False):
+    return subprocess.run(
+        ["git"] + args, cwd=str(cwd), capture_output=True, text=True, check=check
+    )
+
+
+def _log(message):
+    print(message, file=sys.stderr)
+
+
+def reset_submodule(submodule_dir: Path) -> bool:
+    """Discard local changes in *submodule_dir*, dropping any applied patch."""
+    _log(f"  Resetting {submodule_dir.name}...")
+    try:
+        _git(["checkout", "."], cwd=submodule_dir, check=True)
+        _git(["clean", "-fd"], cwd=submodule_dir, check=True)
+    except subprocess.CalledProcessError as e:
+        _log(f"  x Failed to reset {submodule_dir.name}: {e.stderr}")
+        return False
+
+    marker = submodule_dir / MARKER_FILE
+    if marker.exists():
+        marker.unlink()
+    _log(f"  + Reset {submodule_dir.name}")
+    return True
+
+
+def reset_all_submodules() -> bool:
+    """Reset every configured submodule to a clean state."""
+    _log("=" * 60)
+    _log("Resetting submodules to clean state")
+    _log("=" * 60)
+
+    ok = True
+    for submodule_name, _ in PATCHES:
+        submodule_dir = THIRD_PARTY_DIR / submodule_name
+        if not submodule_dir.exists():
+            _log(f"  ! Submodule directory not found: {submodule_dir}")
+            continue
+        if not reset_submodule(submodule_dir):
+            ok = False
+    return ok
+
+
+def _already_applied(patch_file: Path, target_dir: Path) -> bool:
+    """True if *patch_file* is already present in *target_dir*."""
+    return (
+        _git(
+            ["apply", "--check", "--reverse", "--ignore-whitespace", str(patch_file)],
+            cwd=target_dir,
+        ).returncode
+        == 0
+    )
+
+
+# git apply strategies, in escalating order of tolerance. Each entry is
+# (extra flags, short description used in diagnostics).
+_STRATEGIES = [
+    (["--ignore-whitespace"], "ignore-whitespace"),
+    (["--3way", "--ignore-whitespace"], "3-way merge"),
+]
+
+
+def _is_clean(target_dir: Path) -> bool:
+    """True if the submodule working tree has no local modifications."""
+    result = _git(["status", "--porcelain"], cwd=target_dir)
+    return result.returncode == 0 and not result.stdout.strip()
+
+
+def _apply_one(patch_file: Path, target_dir: Path) -> None:
+    """Apply *patch_file* in *target_dir*, or raise :class:`PatchError`.
+
+    Failure is atomic when we started from a clean tree: --3way can apply a
+    patch *with conflict markers* and still report failure, and leaving a
+    half-merged vendored submodule behind would be worse than not trying.
+    """
+    started_clean = _is_clean(target_dir)
+
+    attempts = []
+    for flags, label in _STRATEGIES:
+        if "--3way" in flags and not started_clean:
+            # Refuse to 3-way merge into a tree we cannot safely roll back.
+            attempts.append(
+                f"    via {label}: skipped, {target_dir.name} has local changes"
+            )
+            continue
+        # Dry-run first so a failing strategy cannot leave a partial apply
+        # behind. --3way is exempt: it stages merge results and has no
+        # meaningful --check, so it is attempted directly.
+        if "--3way" not in flags:
+            check = _git(
+                ["apply", "--check"] + flags + [str(patch_file)], cwd=target_dir
+            )
+            if check.returncode != 0:
+                attempts.append(f"    via {label}: {check.stderr.strip()}")
+                continue
+
+        result = _git(["apply"] + flags + [str(patch_file)], cwd=target_dir)
+        if result.returncode == 0:
+            _log(f"  + Applied {patch_file.name} ({label})")
+            return
+        attempts.append(f"    via {label}: {result.stderr.strip()}")
+
+    if started_clean and not _is_clean(target_dir):
+        # A strategy (in practice --3way) left partial or conflicted content.
+        # We know the tree was clean going in, so this restores exactly the
+        # prior state rather than discarding anyone's work.
+        _log(f"  Rolling back partial apply in {target_dir.name}")
+        _git(["reset", "--hard"], cwd=target_dir)
+
+    detail = "\n".join(attempts)
+    raise PatchError(
+        f"Could not apply {patch_file.name} to third_party/{target_dir.name}.\n"
+        f"{detail}\n"
+        "\n"
+        "The usual cause on Windows is git's CRLF conversion rewriting the\n"
+        "submodule working tree. Configure LF and re-checkout, matching what\n"
+        "CI does (.github/workflows/nightly-wheels.yml):\n"
+        "    git config --global core.autocrlf false\n"
+        "    git config --global core.eol lf\n"
+        "    git submodule foreach --recursive git reset --hard\n"
+        "Otherwise the submodule pin and the patch have genuinely diverged."
+    )
+
+
+def apply_patches(force: bool = False, reset: bool = False) -> None:
+    """Apply every configured patch. Raises :class:`PatchError` on failure.
+
+    Args:
+        force: re-apply even when the marker file says it was already done.
+        reset: reset each submodule to a clean state first.
+    """
+    _log("=" * 60)
+    _log("Checking/applying patches to submodules")
+    _log("=" * 60)
+
+    for submodule_name, patch_name in PATCHES:
+        submodule_dir = THIRD_PARTY_DIR / submodule_name
+        patch_file = THIRD_PARTY_DIR / patch_name
+        marker_file = submodule_dir / MARKER_FILE
+
+        _log(f"\n[{submodule_name}]")
+
+        if not submodule_dir.exists():
+            # An uninitialised submodule is not a patch failure -- the build
+            # will report it far more clearly than we can here.
+            _log(f"  ! Submodule directory not found: {submodule_dir}")
+            continue
+
+        if not patch_file.exists():
+            raise PatchError(f"Patch file not found: {patch_file}")
+
+        if reset and not reset_submodule(submodule_dir):
+            raise PatchError(f"Failed to reset third_party/{submodule_name}")
+
+        if marker_file.exists() and not force:
+            _log("  + Patches already applied (marker exists)")
+            continue
+
+        if _already_applied(patch_file, submodule_dir):
+            _log("  + Patch already applied")
+            marker_file.touch()
+            continue
+
+        _log(f"  Applying {patch_name}...")
+        _apply_one(patch_file, submodule_dir)
+        marker_file.touch()
+
+    _log("\n" + "=" * 60)
+    _log("All patches applied successfully.")
+    _log("=" * 60)

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -109,6 +109,11 @@ def run_python_file(
             env=env,
             capture_output=True,
             text=True,
+            # Decode the example's output as UTF-8 rather than the platform
+            # default. Without this, one non-cp1252 byte from a kernel or a
+            # traceback takes down the whole run with UnicodeDecodeError.
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout_sec,
         )
     except subprocess.TimeoutExpired as e:
@@ -152,7 +157,31 @@ def run_python_file(
     return (result.returncode, result.stdout, result.stderr)
 
 
+def _make_output_unicode_safe():
+    """Stop the status emoji from killing the run on a non-UTF-8 console.
+
+    Windows consoles default to cp1252, and Python encodes stdout strictly, so
+    the first "📁" raised UnicodeEncodeError before a single example ran.
+    (stderr survived only because Python defaults it to backslashreplace.)
+    Reconfigure both to UTF-8, and fall back to replacing unencodable
+    characters if the stream cannot be switched.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            try:
+                reconfigure(errors="replace")
+            except (ValueError, OSError):
+                pass
+
+
 def main():
+    _make_output_unicode_safe()
+
     parser = argparse.ArgumentParser(
         description="Run each example under the examples directory and report pass/fail."
     )
@@ -204,7 +233,10 @@ def main():
     if args.log:
         now = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
         log_path = args.log.format(now)
-        log_f = open(log_path, "w")
+        # Explicit encoding: the log carries captured subprocess output, which
+        # routinely contains characters the platform default (cp1252 on
+        # Windows) cannot represent.
+        log_f = open(log_path, "w", encoding="utf-8", errors="replace")
         # Intentionally leave open for entire run
 
     # Determine transform filename based on device

--- a/setup.py
+++ b/setup.py
@@ -65,18 +65,44 @@ AMD_TRITON_NPU_DIR = BASE_DIR / "amd_triton_npu"
 # same strategy as used in TheRock
 # https://github.com/ROCm/TheRock/pull/4006/changes#diff-6812ec4cd824b4a56416cd4ca74afdece86fe8d39c813300eddc0d17194b9e80R153-R155
 
-# Patch configuration: (submodule_name, patch_file)
-PATCHES = [
-    (
-        ("triton-windows", "triton-windows.patch")
-        if IS_WINDOWS
-        else ("triton", "triton.patch")
-    ),
-    ("triton_shared", "triton_shared.patch"),
-]
+# Patch application lives in scripts/patching.py so this file and
+# scripts/apply_patches.py share one implementation. They used to be
+# near-duplicates that had drifted: only one passed --ignore-whitespace, and
+# only the other knew Windows patches triton-windows rather than triton.
+sys.path.insert(0, str(BASE_DIR / "scripts"))
+from patching import PatchError  # noqa: E402
+from patching import apply_patches as _apply_patches  # noqa: E402
 
-# Marker file name to track if patches have been applied
-PATCH_MARKER_FILE = ".patches_applied"
+
+def apply_patches():
+    """Apply the submodule patches, aborting the build if any fails.
+
+    Failing here is the point. This step used to print a warning and carry on,
+    so an unapplied triton_shared.patch surfaced twenty minutes later as a
+    C2397 narrowing-conversion error in PtrAnalysis.cpp with nothing tying it
+    back to patching. sys.exit keeps the explanation readable instead of
+    burying it under a pip traceback.
+    """
+    try:
+        _apply_patches()
+    except PatchError as e:
+        sys.exit(f"\nERROR: {e}\n")
+
+
+def _load_msvc_helper():
+    """Load amd_triton_npu/backend/msvc.py without importing triton.
+
+    That package cannot be imported normally at build time (its __init__ pulls
+    in the triton backend), but msvc.py is deliberately stdlib-only, so load it
+    straight off disk.
+    """
+    import importlib.util
+
+    path = AMD_TRITON_NPU_DIR / "backend" / "msvc.py"
+    spec = importlib.util.spec_from_file_location("_triton_xdna_msvc", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def find_triton_shared_opt_binary(triton_source_dir: Path = None) -> Path:
@@ -123,92 +149,6 @@ def find_triton_shared_opt_binary(triton_source_dir: Path = None) -> Path:
 def check_env_flag(name: str, default: str = "") -> bool:
     """Check if an environment variable is set to a truthy value."""
     return os.getenv(name, default).upper() in ["ON", "1", "YES", "TRUE", "Y"]
-
-
-# =============================================================================
-# Patch Management
-# =============================================================================
-
-
-def apply_submodule_patches():
-    """
-    Apply local patches to third-party submodules before building.
-
-    This function applies patch files from third_party/ to their respective
-    submodules. It uses marker files to track whether patches have been applied
-    to avoid re-applying them on subsequent builds.
-    """
-    print("=" * 60, file=sys.stderr)
-    print("Checking/applying patches to submodules", file=sys.stderr)
-    print("=" * 60, file=sys.stderr)
-
-    for submodule_name, patch_name in PATCHES:
-        submodule_dir = THIRD_PARTY_DIR / submodule_name
-        patch_file = THIRD_PARTY_DIR / patch_name
-        marker_file = submodule_dir / PATCH_MARKER_FILE
-
-        print(f"\n[{submodule_name}]", file=sys.stderr)
-
-        # Check if submodule directory exists
-        if not submodule_dir.exists():
-            print(
-                f"  ⚠ Submodule directory not found: {submodule_dir}", file=sys.stderr
-            )
-            continue
-
-        # Check if patch file exists
-        if not patch_file.exists():
-            print(f"  ⚠ Patch file not found: {patch_file}", file=sys.stderr)
-            continue
-
-        # Check if already applied (marker exists)
-        if marker_file.exists():
-            print(f"  ✓ Patches already applied (marker exists)", file=sys.stderr)
-            continue
-
-        # Check if patch can be applied (dry run)
-        check_result = subprocess.run(
-            ["git", "apply", "--check", str(patch_file)],
-            cwd=submodule_dir,
-            capture_output=True,
-            text=True,
-        )
-
-        if check_result.returncode != 0:
-            # Check if patch is already applied by trying reverse
-            reverse_result = subprocess.run(
-                ["git", "apply", "--check", "--reverse", str(patch_file)],
-                cwd=submodule_dir,
-                capture_output=True,
-                text=True,
-            )
-
-            if reverse_result.returncode == 0:
-                print(f"  ✓ Patch already applied", file=sys.stderr)
-                marker_file.touch()
-            else:
-                print(
-                    f"  ✗ Patch conflict: {check_result.stderr.strip()}",
-                    file=sys.stderr,
-                )
-            continue
-
-        # Apply the patch
-        print(f"  Applying {patch_name}...", file=sys.stderr)
-        apply_result = subprocess.run(
-            ["git", "apply", str(patch_file)],
-            cwd=submodule_dir,
-            capture_output=True,
-            text=True,
-        )
-
-        if apply_result.returncode == 0:
-            print(f"  ✓ Patch applied successfully", file=sys.stderr)
-            marker_file.touch()
-        else:
-            print(f"  ✗ Failed to apply patch: {apply_result.stderr}", file=sys.stderr)
-
-    print("\n" + "=" * 60, file=sys.stderr)
 
 
 # =============================================================================
@@ -355,7 +295,7 @@ class TritonXdnaBdistWheel(bdist_wheel):
 
     def run(self):
         # Apply patches before building
-        apply_submodule_patches()
+        apply_patches()
 
         print("=" * 60, file=sys.stderr)
         print("Building Triton XDNA wheel", file=sys.stderr)
@@ -427,8 +367,22 @@ class TritonXdnaBdistWheel(bdist_wheel):
         # includes a build number, so hand-rolling it would only drift.
 
         # Prepare environment for triton-windows build.
-        # Note: MSVC environment (vcvars64.bat) must already be set up.
+        #
+        # A developer prompt is no longer required. If INCLUDE is unset we run
+        # vcvars64.bat ourselves and adopt the environment it produces; without
+        # it CMake only reports that it cannot find the compiler named by $CXX,
+        # which says nothing about Visual Studio.
         windows_env = dict(os.environ)
+        msvc = _load_msvc_helper()
+        if msvc.in_developer_environment():
+            print("  MSVC: using the developer environment already in scope")
+        else:
+            vc_env = msvc.vcvars_env()
+            if vc_env is None:
+                sys.exit(f"\nERROR: {msvc.SETUP_HINT}\n")
+            print(f"  MSVC: initialised from {msvc.find_vcvars()}")
+            windows_env.update(vc_env)
+
         windows_env.update(
             {
                 "PYTHONUTF8": "1",
@@ -885,7 +839,7 @@ class TritonXdnaDevelop(develop):
             self._copy_triton_shared_opt()
         else:
             # Build triton from source with plugins
-            apply_submodule_patches()
+            apply_patches()
             env = os.environ.copy()
             plugin_dirs = f"{TRITON_SHARED_DIR};{AMD_TRITON_NPU_DIR}"
             env["TRITON_PLUGIN_DIRS"] = plugin_dirs
@@ -967,7 +921,7 @@ class TritonXdnaInstall(install):
                     os.chmod(dst_binary, 0o755)
         else:
             # Build triton from source with plugins
-            apply_submodule_patches()
+            apply_patches()
 
             env = os.environ.copy()
             plugin_dirs = f"{TRITON_SHARED_DIR};{AMD_TRITON_NPU_DIR}"

--- a/utils/env_setup.ps1
+++ b/utils/env_setup.ps1
@@ -5,9 +5,10 @@
 # Usage: . .\utils\env_setup.ps1
 #
 # Prerequisites:
-#   - Python 3.10, 3.11, or 3.12 (Xilinx Windows wheels do not yet support 3.13+)
+#   - Python 3.11-3.14 (3.13 recommended: the prebuilt pyxrt.pyd targets it)
 #   - A virtual environment activated (e.g. python -m venv venv && .\venv\Scripts\Activate.ps1)
-#   - XRT SDK at C:\Program Files\AMD\xrt (download xrt_windows_sdk.zip from XRT releases)
+#   - XRT SDK at C:\Program Files\AMD\xrt, or XRT_DEV_DIR pointing at it
+#     (download xrt_windows_sdk.zip from XRT releases)
 
 $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -107,9 +108,19 @@ Write-Host "Environment setup complete."
 # Download xrt_windows_sdk.zip from https://github.com/Xilinx/XRT/releases and
 # extract the inner xrt_sdk/xrt/ directory to C:\Program Files\AMD\xrt
 # (the zip's top-level folder is xrt_sdk/, not xrt/).
-$xrtDefault = Join-Path $env:PROGRAMFILES "AMD\xrt"
-if (Test-Path (Join-Path $xrtDefault "include\xrt\xrt_bo.h")) {
-    Write-Host "XRT SDK found at: $xrtDefault"
+# Checked in the same order the backend searches, so this reports what the
+# build will actually find.
+$xrtCandidates = @()
+if ($env:AMD_TRITON_NPU_XRT_DIR) { $xrtCandidates += $env:AMD_TRITON_NPU_XRT_DIR }
+if ($env:XRT_DEV_DIR)            { $xrtCandidates += $env:XRT_DEV_DIR }
+$xrtCandidates += (Join-Path $env:PROGRAMFILES "AMD\xrt")
+
+$xrtFound = $xrtCandidates | Where-Object {
+    Test-Path (Join-Path $_ "include\xrt\xrt_bo.h")
+} | Select-Object -First 1
+
+if ($xrtFound) {
+    Write-Host "XRT SDK found at: $xrtFound"
 } else {
-    Write-Warning "XRT SDK not found at $xrtDefault. Download xrt_windows_sdk.zip from XRT releases and move the inner xrt_sdk/xrt/ folder there."
+    Write-Warning "XRT SDK not found (looked in: $($xrtCandidates -join ', ')). Download xrt_windows_sdk.zip from https://github.com/Xilinx/XRT/releases, extract the inner xrt_sdk/xrt/ folder, and either place it at $(Join-Path $env:PROGRAMFILES 'AMD\xrt') or point XRT_DEV_DIR at it."
 }

--- a/utils/setup_xrt_dev.ps1
+++ b/utils/setup_xrt_dev.ps1
@@ -16,9 +16,11 @@
 #   .\utils\setup_xrt_dev.ps1 [-XrtDll <path>] [-OutputDir <path>]
 #
 # After running, set the environment variable:
-#   $env:XILINX_XRT = "<OutputDir>"
-#   # -- or --
 #   $env:XRT_DEV_DIR = "<OutputDir>"
+#
+# Use XRT_DEV_DIR, not XILINX_XRT. Both are honoured, but xrt_coreutil.dll also
+# reads XILINX_XRT and then demands an xrt_core.dll that the Windows NPU driver
+# does not ship, which breaks device detection and kernel dispatch.
 #
 # Prerequisites:
 #   - Git
@@ -152,9 +154,11 @@ if ($headerOk -and $libOk -and $dllOk) {
     Write-Host " XRT development files ready!" -ForegroundColor Green
     Write-Host "========================================" -ForegroundColor Green
     Write-Host ""
-    Write-Host "Set one of these environment variables:"
-    Write-Host "  `$env:XILINX_XRT = `"$OutputDir`""
+    Write-Host "Set this environment variable:"
     Write-Host "  `$env:XRT_DEV_DIR = `"$OutputDir`""
+    Write-Host ""
+    Write-Host "Do not use XILINX_XRT for this: xrt_coreutil.dll reads it too" -ForegroundColor Yellow
+    Write-Host "and then requires an xrt_core.dll the NPU driver does not ship." -ForegroundColor Yellow
     Write-Host ""
     Write-Host "Contents:"
     Write-Host "  include/xrt/       - XRT C++ headers"


### PR DESCRIPTION
Bringing the project up on a Windows npu2 host hit four issues, each of which failed somewhere far from its cause. None were in the NPU stack — all were in our own tooling.

## 1. Patching silently did nothing

Windows' `core.autocrlf=true` rewrites the submodule working trees to CRLF, and the `third_party` patches are authored with LF, so `git apply` rejected every hunk. `setup.py` printed a warning and carried on, so the build ran **unpatched** for twenty minutes and then died with a C2397 narrowing error in `PtrAnalysis.cpp` — the exact error `triton_shared.patch` exists to prevent.

Two copies of the patch logic had also drifted:

- only `scripts/apply_patches.py` passed `--ignore-whitespace`
- only `setup.py` knew Windows patches `triton-windows` rather than `triton`, so the standalone script patched the **wrong submodule** entirely

Consolidated into `scripts/patching.py`: applies with `--ignore-whitespace`, falls back to a `--3way` merge, and **raises** rather than continuing. A failed apply is rolled back so a vendored submodule is never left half-merged. `.gitattributes` pins the patch files to LF so the patch side is correct regardless of the user's git config; the submodule side can't be governed that way, which is why the tolerant apply flags remain.

The project already knew about this trap — it's fixed in `.github/workflows/nightly-wheels.yml` for the wheel job, but nothing in the build itself was defensive about it.

## 2. `XILINX_XRT` was a trap

The driver reads it to find XRT development files, but `xrt_coreutil.dll` reads it too and then demands an `xrt_core.dll` that the NPU-only Windows driver stack never ships. Setting it broke **both** device detection and kernel dispatch with `No such library ...xrt_core.dll`.

Prefer `XRT_DEV_DIR` (which `utils/setup_xrt_dev.ps1` already advertised but nothing read) and `npu_config.xrt_dir`, both ahead of `XILINX_XRT`. When a hostile `XILINX_XRT` is set anyway, warn and drop it from the environment while still using its value for headers. That has to happen before the first pyxrt call, so it runs from `NPUDriver.__init__` and `_pyxrt_device_name`, not only from `_get_xrt_path`.

## 3. The build assumed a developer prompt

`setup.py` hardcodes `CC`/`CXX=cl.exe`, so outside an x64 Native Tools shell CMake failed with a message about `$CXX` that never mentioned Visual Studio. New `amd_triton_npu/backend/msvc.py` locates VS with `vswhere` and captures a real `vcvars64.bat` environment. `setup.py` uses it when `INCLUDE` is unset; `driver.py`'s JIT path prefers it over its hand-rolled `INCLUDE`/`LIB` derivation, which misses `rc.exe` and `mt.exe`. `vswhere -latest` is version-agnostic, so VS 2022 and VS 18 both work.

## 4. `run_tests.py` could not run on a stock Windows console

It prints status emoji to a strict-cp1252 stdout and died with `UnicodeEncodeError` before executing a single test. It also decoded captured subprocess output with the platform default, so one stray byte from an example would have taken down a whole run. Forced UTF-8 on both sides.

## Verification

On an AIE2P host (XRT reports `NPU Krackan`):

| Case | Before | After |
| --- | --- | --- |
| LF patch vs CRLF submodule | hunks rejected | applies via `--ignore-whitespace` |
| Genuinely unappliable patch | warn, build 20 min, C2397 | exits 1 naming patch + submodule, tree left clean |
| `XILINX_XRT` set, kernel dispatch | `No such library ...xrt_core.dll` | succeeds, warns and self-heals |
| `pip install .` from a plain shell | CMake `$CXX` failure | succeeds |
| `run_tests.py`, no `PYTHONIOENCODING` | `UnicodeEncodeError`, 0 tests run | runs to completion |
| Example suite, prebuilt wheel | 20/22 | 20/22 |
| Example suite, from-source build | 20/22 | 20/22 |

The two suite failures are unchanged and unrelated: `gpt2_inference.py` and `qwen_inference.py` need HuggingFace weights that the test network blocks with `CERTIFICATE_VERIFY_FAILED`. Their NPU kernel halves (`model.py`) pass.

Linux behaviour is unchanged: the patch list still resolves to `('triton', 'triton.patch')`, the XRT changes are additive lookup entries, and the `XILINX_XRT` neutralizer returns early off-Windows.

Net `+704/-326`, a reduction in real logic once the duplicated patch implementation is removed. `black --check` passes on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
