### PR TITLE
Bump mlir-air to 36ce5af for the multi-launch dispatch-reuse fix

### DIFF
--- a/utils/mlir-air-hash.txt
+++ b/utils/mlir-air-hash.txt
@@ -1,3 +1,3 @@
-Commit: d0e522b
-Timestamp: 2026081604
+Commit: 36ce5af
+Timestamp: 2026082904
 Version: 0.0.1


### PR DESCRIPTION
Bumps the pinned mlir-air to `0.0.1.2026082904+36ce5af`, whose `[aie]` extra pins `mlir_aie_no_rtti==1.4.3.dev31+gaf819a8` — that is Xilinx/mlir-aie#3622, *"[AIEExpandLoadPdi] Keep the empty-PDI reset alternating across dispatches"*.

Fixes #99.

## Why

`AIEExpandLoadPdi` rewrites each `load_pdi @device` into a load of an **empty** PDI — that load is what actually resets the array — followed by explicit `write32`/`blockwrite` configuration. The firmware caches the PDI address, so loading the same PDI twice in a row is a no-op, and the pass alternates `empty_ + (index % 2)` to avoid it.

But `index` is the module-wide `load_pdi` index, so the alternation only held *within* one runtime sequence. The host re-runs the whole sequence on every dispatch, so it has to hold across that boundary too. A sequence with an **odd** number of resets ends on the same empty PDI it started with, so the next dispatch's reset was swallowed and the configuration landed on a device still holding the previous run's lock and DMA state:

| ops | resets per dispatch | at the dispatch boundary |
|-----|---------------------|--------------------------|
| 1 | `empty_0` | `empty_0` → `empty_0` — **cached, no reset** |
| 2 | `empty_0, empty_1` | `empty_1` → `empty_0` — ok |
| 3 | `empty_0, empty_1, empty_0` | `empty_0` → `empty_0` — **cached, no reset** |
| 4 | `empty_0, empty_1, empty_0, empty_1` | ok |

For `NPUChain` that meant any chain with an odd number of ops was correct on its first dispatch and non-deterministically wrong on every one after — around 5% of elements per dispatch, scattered over ~60 of 96 blocks, always at the *start* of a block and always skewed by exactly one grid iteration (`got[i] == want[i + BLOCK_SIZE]`). `examples/gpt2` was unaffected only because its fused MLP chain happens to have four ops. Uniform test data hides it entirely.

## Testing

On Strix Halo (npu2/aie2p, XRT 2.21.75, firmware 1.1.2.65), running the #99 reproducer extended to four chain lengths, three consecutive dispatches each:

| ops | before | after |
|---|---|---|
| 1 | dispatch 0 OK, 1–2 WRONG | all OK |
| 2 | all OK | all OK |
| 3 | dispatch 0 OK, 1–2 WRONG | all OK |
| 4 | all OK | all OK |

The "after" column was measured against the **released wheels** (`mlir_air-0.0.1.2026082904+36ce5af.no.rtti-cp313` plus the `mlir_aie_no_rtti-1.4.3.dev31+gaf819a8` it pins), not a local source build, so it exercises exactly what CI and `pip install` will resolve.

## Scope

`utils/mlir-air-hash.txt` is the single source of truth — `setup.py`, `utils/env_setup.sh`, and `.github/workflows/build.yml` all parse it, and the README references it without embedding a literal. So this is a one-file change. The matching mlir-aie commit comes in transitively via the air wheel's `[aie]` extra; nothing else needs pinning.