### PR TITLE
gpt2: acquire NPU device before HuggingFace model load

### DIFF
--- a/examples/gpt2/gpt2_inference.py
+++ b/examples/gpt2/gpt2_inference.py
@@ -418,6 +418,15 @@ def main():
 
     args.config = GPT2_CONFIGS[args.model]
 
+    if args.backend in ("npu", "hetero", "hetero-fast"):
+        # On some platforms, a HIP/ROCm context created anywhere in the process
+        # permanently blocks new NPU device opens. Acquire the NPU device now,
+        # before HuggingFace/transformers below can trigger CUDA init.
+        import pyxrt
+
+        global _npu_device_handle
+        _npu_device_handle = pyxrt.device(0)
+
     # Load HuggingFace model
     hf_model, tokenizer = load_hf_model(args.config["hf_name"])
 


### PR DESCRIPTION
### Problem
On some platforms (confirmed on Strix Halo), once a ROCm/HIP compute context is initialized anywhere in the process, `/dev/accel/accel0` permanently refuses new opens (`err=-16`, EBUSY) for the rest of that process's lifetime. `transformers.AutoModelForCausalLM.from_pretrained()` triggers this internally (via an implicit CUDA availability check) during `load_hf_model()`, which runs before `GPT2Model` is ever constructed. As a result, every NPU kernel dispatch in `--backend npu`/`hetero`/`hetero-fast` silently falls back to PyTorch (a `logger.warning`, easy to miss) — the example still exits 0 and prints plausible-looking generated text, but never actually touches the NPU.

Fixes #103.

### Fix
Acquire (and hold) `pyxrt.device(0)` at the top of `main()`, before `load_hf_model()` runs, for backends that need both NPU and GPU. This is cheap and a no-op on platforms without this constraint; on platforms with it, it fixes the ordering at the source.

### Verification
Ran `examples/gpt2/gpt2_inference.py` on a Strix Halo NPU before/after the fix:
- Before: every op (layernorm/linear/softmax/add) across all layers falls back to PyTorch with an `EBUSY` warning.
- After: zero fallback warnings, `Top-1 match: YES` against the HuggingFace reference logits, for both `--backend npu` and `--backend hetero`, in both single-forward-pass (`--max-tokens 0`) and multi-token generation (`--max-tokens 12`) modes.