### PR TITLE
CI: bump actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
        large-packages: true
        swap-storage: false
    - name: Get repo
-     uses: actions/checkout@v3
+     uses: actions/checkout@v4
      with:
       fetch-depth: 2
       submodules: recursive

--- a/.github/workflows/small.yml
+++ b/.github/workflows/small.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, docker]
     steps:
       - name: Pull
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         env:
           HOME: /workspace
         with:


### PR DESCRIPTION
`actions/checkout@v3` targets Node.js 20, which the runners now force onto Node.js 24 while emitting a deprecation warning on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v3.

`format.yml`, `generate-dashboard.yml`, and `nightly-wheels.yml` are already on v4. This brings the last two holdouts (`build.yml`, `small.yml`) in line. No behavior change — the inputs used (`fetch-depth`, `submodules`, `token`) are unchanged between v3 and v4.

Note this does *not* address the separate fork-PR issue seen in #104, where `small.yml`'s `token: ${{ secrets.RUNNER_PAT }}` resolves to empty for fork PRs (secrets are not exposed) and checkout fails with `Input required and not supplied: token`. That needs its own decision about whether fork code should run on the self-hosted NPU runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)