### PR TITLE
Preload mlir-air LLVM to avoid ROCm LLVM ABI collision (#102)

### DIFF
--- a/amd_triton_npu/backend/__init__.py
+++ b/amd_triton_npu/backend/__init__.py
@@ -1,2 +1,14 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
+
+# Force mlir-air's statically-linked LLVM to load before any ROCm SDK LLVM.
+# A ROCm PyTorch install (e.g. TheRock/gfx1151) transitively pulls in its own
+# libLLVM.so.23 via libamdhip64 -> libhipblaslt. Under ELF first-loaded-wins
+# symbol resolution, whichever LLVM loads first wins the global namespace; if
+# ROCm's wins, mlir-air's libAirAggregateCAPI.so constructor binds the wrong
+# LLVM globals and segfaults (issue #102). Importing air's own LLVM-linked
+# bindings here makes mlir-air's symbols win before triton_shared is loaded.
+try:
+    import air._mlir_libs._mlir  # noqa: F401
+except Exception:
+    pass


### PR DESCRIPTION
A ROCm PyTorch install (e.g. TheRock/gfx1151) transitively pulls in its own libLLVM.so.23 via libamdhip64 -> libhipblaslt. Under ELF first-loaded-wins symbol resolution, if ROCm's LLVM wins the global namespace before mlir-air initializes, mlir-air's libAirAggregateCAPI.so constructor binds the wrong LLVM globals and aborts/segfaults.

Importing air's own LLVM-linked bindings from the backend package __init__ (loaded via the triton.backends entry point before compiler.py pulls in triton_shared) forces mlir-air's LLVM symbols to win first, closing the collision automatically. Guarded so it is a no-op when air is not installed.

Fixes #102