### PR TITLE
qwen2_5: acquire NPU device before HuggingFace model load

### DIFF
--- a/examples/qwen2_5/qwen_inference.py
+++ b/examples/qwen2_5/qwen_inference.py
@@ -343,6 +343,14 @@ def main():
     )
 
     args.config = QWEN_CONFIGS[args.model]
+
+    if args.backend in ("npu", "hetero", "hetero-fast"):
+        # Grab the NPU before transformers can init HIP (see #103).
+        import pyxrt
+
+        global _npu_device_handle
+        _npu_device_handle = pyxrt.device(0)
+
     hf_model, tokenizer = load_hf_model(args.config["hf_name"])
 
     if args.interactive:


### PR DESCRIPTION
Qwen2Model.__init__ moves the LM-head weight to cuda (model.py:611) for backend in (npu, hetero, hetero-fast), initializing a HIP context before any NPU op dispatches. On platforms where a HIP context blocks new NPU device opens (EBUSY), every NPU launch then silently falls back to PyTorch. Acquire and hold pyxrt.device(0) at the top of main(), before load_hf_model() runs, so the NPU open wins first. No-op where the constraint does not exist.

Same fix as #104 (gpt2), applied to the qwen2_5 example.

Fixes #103 for qwen example