### PR TITLE
Bump mlir-air to 6746658, and pin llvm-aie to the nightly it was built against

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -60,9 +60,10 @@ runs:
           -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
           -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
           -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-      # The [aie] extra requires llvm-aie without a version pin. Force an
-      # upgrade so we always test against the latest nightly wheel.
-      python3 -m pip install --no-cache-dir --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+      # The [aie] extra requires llvm-aie without a version pin, so a cached
+      # or transitively-installed one would silently satisfy it. Force the
+      # pinned one; see utils/peano-requirements.txt for which and why.
+      python3 -m pip install --no-cache-dir --upgrade --force-reinstall -r utils/peano-requirements.txt
       python3 -m pip show llvm-aie
       python3 -m pip show mlir_aie_no_rtti
       # Set environmental variable "MLIR_AIE_INSTALL_DIR"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,10 @@ jobs:
           -f https://github.com/Xilinx/mlir-air/releases/expanded_assets/latest-air-wheels-no-rtti \
           -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
           -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-      # The [aie] extra requires llvm-aie without a version pin. Force an
-      # upgrade so we always test against the latest nightly wheel.
-      python3 -m pip install --upgrade --force-reinstall llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+      # The [aie] extra requires llvm-aie without a version pin, so a cached
+      # or transitively-installed one would silently satisfy it. Force the
+      # pinned one; see utils/peano-requirements.txt for which and why.
+      python3 -m pip install --upgrade --force-reinstall -r utils/peano-requirements.txt
       python3 -m pip show llvm-aie
       python3 -m pip show mlir_aie_no_rtti
       # Set environmental variable "MLIR_AIE_INSTALL_DIR"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This will automatically install all required dependencies:
 - llvm-aie
 - mlir-air
 
-The mlir-air version is pinned in `utils/mlir-air-hash.txt`. The matching mlir-aie commit is pinned by the mlir-air wheel's `[aie]` extra, so it's resolved transitively. llvm-aie uses the latest nightly release.
+The mlir-air version is pinned in `utils/mlir-air-hash.txt`. The matching mlir-aie commit is pinned by the mlir-air wheel's `[aie]` extra, so it's resolved transitively. llvm-aie is pinned in `utils/peano-requirements.txt`, to the nightly that the pinned mlir-aie was itself built against -- the `[aie]` extra requires it without a version, so otherwise an install would take whatever nightly happened to be newest that day.
 
 #### Option 3: Build from Source (Using Cmake)
 

--- a/setup.py
+++ b/setup.py
@@ -243,13 +243,27 @@ def _make_version_spec(pkg_name, version, timestamp, short_commit, suffix=""):
     return f"{pkg_name}=={full}"
 
 
+def parse_peano_pin(path: Path) -> str:
+    """The pinned llvm-aie requirement from utils/peano-requirements.txt.
+
+    The file is also fed to `pip install -r` by CI and env_setup, so it is the
+    one place the version lives.
+    """
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("llvm-aie=="):
+            return line
+    raise RuntimeError(f"no pinned llvm-aie requirement in {path}")
+
+
 def get_install_requires():
     """Build install_requires list from hash files.
 
-    Only mlir-air is pinned here. The mlir-air wheel exposes an [aie] extra
-    that pins the matching mlir-aie commit and requires llvm-aie, so we get a
-    guaranteed-compatible mlir-aie transitively without having to pin it
-    ourselves.
+    mlir-air is pinned here, and its [aie] extra pins the matching mlir-aie
+    commit -- so that one comes transitively. llvm-aie does NOT: the extra
+    requires it without a version, so an install would otherwise take whatever
+    nightly is newest that day rather than the one the pinned mlir-aie was
+    built and tested against. Pin it explicitly, from the same file CI uses.
     """
     mlir_air_hash_file = BASE_DIR / "utils" / "mlir-air-hash.txt"
 
@@ -263,6 +277,7 @@ def get_install_requires():
 
     return [
         f"mlir-air[aie]=={mlir_air_full_version}",
+        parse_peano_pin(BASE_DIR / "utils" / "peano-requirements.txt"),
     ]
 
 

--- a/utils/env_setup.ps1
+++ b/utils/env_setup.ps1
@@ -55,11 +55,11 @@ python -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SHO
     -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 `
     -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
-# The [aie] extra requires llvm-aie without a version pin. To track the
-# nightly wheel, force-upgrade llvm-aie explicitly so an existing installation
-# doesn't silently satisfy the unpinned requirement.
-python -m pip install --upgrade llvm-aie `
-    -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+# The [aie] extra requires llvm-aie without a version pin, so an existing
+# installation would silently satisfy it. Force the pinned one; see
+# utils/peano-requirements.txt for which version and why.
+python -m pip install --upgrade --force-reinstall `
+    -r (Join-Path $ScriptDir "peano-requirements.txt")
 
 if (-not $env:MLIR_AIE_INSTALL_DIR) {
     $MLIR_AIE_INSTALL_DIR = (python -c "import importlib.util; spec = importlib.util.find_spec('mlir_aie'); print(spec.submodule_search_locations[0])")

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -28,11 +28,10 @@ python3 -m pip install "mlir_air[aie]==$MLIR_AIR_VERSION.$MLIR_AIR_TIMESTAMP+$SH
     -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-no-rtti-2 \
     -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 
-# The [aie] extra requires llvm-aie without a version pin. To track the
-# nightly wheel (matching the prior env_setup.sh behavior), force-upgrade
-# llvm-aie explicitly so an existing installation doesn't silently satisfy
-# the unpinned requirement.
-python3 -m pip install --upgrade llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+# The [aie] extra requires llvm-aie without a version pin, so an existing
+# installation would silently satisfy it. Force the pinned one; see
+# utils/peano-requirements.txt for which version and why.
+python3 -m pip install --upgrade --force-reinstall -r "$(dirname "${SCRIPT_PATH}")/peano-requirements.txt"
 
 fi  # TRITON_XDNA_ENV_INSTALL
 

--- a/utils/mlir-air-hash.txt
+++ b/utils/mlir-air-hash.txt
@@ -1,3 +1,3 @@
-Commit: 36ce5af
-Timestamp: 2026082904
+Commit: 6746658
+Timestamp: 2026090504
 Version: 0.0.1

--- a/utils/peano-requirements.txt
+++ b/utils/peano-requirements.txt
@@ -1,0 +1,12 @@
+# Pinned llvm-aie (Peano) nightly, installed at every CI and env-setup site via
+# `pip install -r`. The [aie] extra requires llvm-aie without a version, so
+# without this the resolver takes whatever nightly is newest that day.
+#
+# Keep this in step with the llvm-aie that the pinned mlir-aie itself pins --
+# its own utils/peano-requirements.txt at the commit mlir-air's [aie] extra
+# selects (see utils/mlir-air-hash.txt). A mismatch there is not tested
+# upstream, and the LLVM 21 -> 22 transition showed what that costs: the newer
+# Peano grew the AIE core stack frame past the device default, which presented
+# as NaN rather than as an error (mlir-air #1980).
+-f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+llvm-aie==22.0.0.2026090201+a36c62b9


### PR DESCRIPTION
Two commits: bump the pinned mlir-air, then stop letting llvm-aie float.

## 1. Bump mlir-air

Bumps the pinned mlir-air from `36ce5af` to `6746658`. The `[aie]` extra
carries the matching mlir-aie with it (`1.4.3.dev31+gaf819a8` ->
`1.4.3.dev55+g10767b5`), so this one line moves the whole MLIR-AIE/AIR stack.
`llvm-aie` is unpinned here and tracks its own nightly.

```
-Commit: 36ce5af
-Timestamp: 2026082904
+Commit: 6746658
+Timestamp: 2026090504
```

## What comes in

**[mlir-air#1980](https://github.com/Xilinx/mlir-air/pull/1980)** moves llvm-aie
to 22 and makes `air-to-aie` emit `stack_size` unconditionally at a 2048
default. LLVM 22 grows the AIE core stack frame for some kernels from 960 to
1216 bytes, past the 1024-byte device default; the overflow landed in the
core's own L1 buffers and presented as NaN rather than as an error.

**This repo is unaffected by that change**, because `driver.py` already passes
`--stack-size 2048` explicitly. That explicit value is also what kept us off
the failure in the first place — the bug only bit designs that inherited the
default.

**[mlir-air#1979](https://github.com/Xilinx/mlir-air/pull/1979)** and
**[#1978](https://github.com/Xilinx/mlir-air/pull/1978)**: a herd's runtime
scalar and a runtime BD offset can now go through mlir-aie scratchpad
parameters on the full-ELF path. Before this, a design with a dispatch-time
scalar could not target `output-format=elf` at all — it failed with `Cannot
translate write32 with non-constant address or value to a static TXN binary`.
ELF is the npu2 default in `driver.py`, so that gap applied to any Strix build.

**[mlir-aie#3679](https://github.com/Xilinx/mlir-aie/pull/3679)**, the tip of
the new pin: the runtime-sequence materializer now looks inside nested regions.
Any AIR design whose segment sequence contains an `scf.for` needs this to
produce an ELF at all.

`aircc`'s option surface is unchanged across the window apart from one internal
addition, so `driver.py`'s invocation needs no adjustment. No other file in the
repo references the old pin.

## Validation

On NPU2 (Strix). Both pins installed side by side into scratch venvs resolving
the **same** llvm-aie nightly (`22.0.0.2026090901+3e93bf7b`), so the air/aie
bump is the only variable.

`scripts/run_tests.py --device aie2p`:

| | |
|---|---:|
| passed | 20 |
| failed | 2 |
| skipped | 2 |

The two skips are `zero_copy` (needs a ROCm build of torch, absent here). The
two failures are `gpt2_inference` and `qwen_inference`, and **both fail
identically on the old pin** with `RuntimeError: 0 active drivers` — a driver
registration problem in my local build, not a regression. Every other example
passes on the new pin, including `vec-add` across six sizes, the matmuls, and
the elementwise and norm kernels.

As a second check on the parts of the stack the examples do not reach, the
fused decode was rebuilt from the released wheels alone — no local trees — and
its logits are bitwise identical to references at three context lengths:

```
L=   64  identical=True  kv-pos=63
L= 1024  identical=True  kv-pos=1023
L= 2048  identical=True  kv-pos=2047
```

## 2. Pin llvm-aie

The `[aie]` extra requires `llvm-aie` without a version, so every install took
whatever nightly was newest that day -- and `build.yml`, `actions/build` and
both `env_setup` scripts force-reinstalled the newest one on top, deliberately,
"so we always test against the latest nightly wheel".

That left two of three toolchain components pinned and the third floating. The
bump above resolved llvm-aie to `22.0.0.2026090901+3e93bf7b`, **seven days
ahead** of the `22.0.0.2026090201+a36c62b9` that mlir-aie `10767b5` names in its
own `utils/peano-requirements.txt`, and that mlir-air validated against. It
worked -- but a green PR could go red overnight with no change to this repo,
which is a poor trade during an LLVM major transition. mlir-air #1980 spent
exactly that window chasing NaN that turned out to be an AIE core stack frame,
not a compiler bug.

`utils/peano-requirements.txt` is the single source, mirroring the mlir-aie
file the version comes from. CI, both env_setup scripts, and now the **wheel
metadata** read it -- so the pin reaches installed users, not just builders.
`--force-reinstall` stays, because the unpinned transitive requirement is
satisfied by any llvm-aie and pip would otherwise leave whatever is present.

Bumping it later is a one-line edit in one file. This intentionally drops the
"track the latest nightly" behaviour; there is no canary job left watching it.

### Verified

Installing the air pin and then `pip install -r utils/peano-requirements.txt`
moves llvm-aie `22.0.0.2026090901+3e93bf7b` -> `22.0.0.2026090201+a36c62b9`,
which is what CI and env_setup will now do. `run_tests.py --device aie2p` on
that environment: **20 passed, 2 skipped, 2 failed** -- identical to the
floating nightly, same two pre-existing failures.

One run of the suite on the pinned peano showed a third failure, `vec-add`.
That is the memtile lock race the repo already documents for small vec-add
tiles, not a peano difference: vec-add passes 4/4 standalone on the pinned
build, and a repeat of the full suite came back 20/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
