### PR TITLE
Remove iGPU dependency from e2e models in npu mode

### DIFF
--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -182,3 +182,17 @@ runs:
         fi
         echo "Target device: $DEVICE"
         python scripts/run_tests.py --device "$DEVICE" --verbose --timeout 1200
+
+        echo ""
+        echo "=========================================="
+        echo "STEP 9: LLM examples in NPU-only mode"
+        echo "=========================================="
+        # gpt2/qwen are the end-to-end iGPU-free gate. They default to --backend
+        # npu, so run_tests invokes them in npu mode; the iGPU is hidden here so a
+        # stray cuda/HIP touch fails the job rather than silently using the iGPU.
+        # transformers/numpy/ml_dtypes are their runtime deps (CPU-only, no ROCm);
+        # if the HuggingFace hub is unreachable the examples exit 77 = SKIP.
+        pip install --no-cache-dir transformers numpy ml_dtypes
+        CUDA_VISIBLE_DEVICES="" HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" \
+          python scripts/run_tests.py --device "$DEVICE" --verbose --timeout 1200 \
+            -t gpt2 -t qwen2_5

--- a/amd_triton_npu/backend/multilaunch.py
+++ b/amd_triton_npu/backend/multilaunch.py
@@ -531,17 +531,23 @@ class NPUChain:
         Forces the NPU driver active for the warmup so the kernel lowers through
         the NPU backend (whose binary_ext is ``ttsharedir``). Without this, in a
         hetero model the GPU driver may be active and ``asm`` would lack
-        ``ttsharedir`` (KeyError). The previously-active driver is restored.
+        ``ttsharedir`` (KeyError).
+
+        Restores the driver active on entry rather than ``reset_active()``, which
+        resolves the auto-detected default and fails with "0 active drivers" on
+        an iGPU-free host (no auto-active GPU driver; NPUDriver is set explicitly,
+        not detected).
         """
         import triton
         from .driver import NPUDriver
 
+        prev = triton.runtime.driver.active
         triton.runtime.driver.set_active(NPUDriver())
         try:
             with config_context(compile_only=True):
                 compiled = kernel.warmup(*args, grid=grid, **constexprs)
         finally:
-            triton.runtime.driver.reset_active()
+            triton.runtime.driver.set_active(prev)
         return compiled.asm["ttsharedir"]
 
     def _build(self):

--- a/examples/gpt2/README.md
+++ b/examples/gpt2/README.md
@@ -19,16 +19,18 @@ every size with no changes.
 
 ## Setup
 
-**Prerequisite: a ROCm torch device is required for all backends except
-`reference`.** Every mode — including `--backend npu` — runs the LM head on
-the iGPU (see the routing table below), so a working ROCm/Triton GPU with a
-ROCm build of PyTorch must be installed.
+**`--backend npu` runs on the NPU and CPU only — no iGPU, so it needs neither a
+ROCm GPU nor a ROCm build of PyTorch.** The `gpu`, `hetero`, and `hetero-fast`
+modes do require a ROCm torch device; `reference` needs neither. See the routing
+table below.
 
 ```bash
 # Prerequisites
 pip install transformers
-# ROCm PyTorch (adjust the ROCm version to match your install)
-pip install torch --index-url https://download.pytorch.org/whl/rocm6.2
+# torch: a CPU build is enough for `npu` and `reference`; use a ROCm build for
+# the gpu/hetero modes (adjust the ROCm version to match your install).
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+# pip install torch --index-url https://download.pytorch.org/whl/rocm6.2
 
 # Environment setup (required for NPU/hetero modes)
 source /opt/xilinx/xrt/setup.sh
@@ -68,17 +70,23 @@ Four backends route operators across devices differently:
 | Backend | Description |
 |---------|-------------|
 | `gpu` | All ops on iGPU via ROCm/Triton |
-| `npu` | All ops on NPU via MLIR-AIR/AIE, except the LM head (GPU) |
+| `npu` | NPU + CPU only, no iGPU: matmuls/LN/MLP/LM head on the NPU, the attention scores/softmax/attn·V core on CPU (no NPU attention kernel yet) |
 | `hetero` | MLP on NPU; everything else (embeddings, LN, attention, LM head) on GPU |
 | `hetero-fast` | Same as hetero for prefill; all-GPU decode |
 
 ### Per-Op Device Routing
 
+In `gpu`/`hetero`/`hetero-fast`, attention is one fused GPU kernel. In `npu` it
+is split: the projections run on the NPU and the scores/softmax/attn·V core on
+CPU (there is no NPU attention kernel yet), so those rows are broken out below.
+
 | Op | `gpu` | `npu` | `hetero` | `hetero-fast` prefill | `hetero-fast` decode |
 |----|-------|-------|----------|----------------------|---------------------|
 | LayerNorm (ln1) | GPU | NPU | **GPU** | **GPU** | GPU |
 | QKV projection | GPU | NPU | GPU | GPU | GPU |
-| Fused attention | GPU | NPU | GPU | GPU | GPU |
+| Attention scores (Q·Kᵀ) | GPU (fused) | CPU | GPU (fused) | GPU (fused) | GPU (fused) |
+| Softmax | GPU (fused) | NPU | GPU (fused) | GPU (fused) | GPU (fused) |
+| Attention · V | GPU (fused) | CPU | GPU (fused) | GPU (fused) | GPU (fused) |
 | Output projection | GPU | NPU | GPU | GPU | GPU |
 | Residual add | GPU | NPU | **GPU** | **GPU** | GPU |
 | LayerNorm (ln2) | GPU | NPU | **GPU** | **GPU** | GPU |
@@ -87,7 +95,7 @@ Four backends route operators across devices differently:
 | MLP down-proj | GPU | NPU | NPU | NPU | **GPU** |
 | Residual add | GPU | NPU | NPU | NPU | **GPU** |
 | Final LayerNorm | GPU | NPU | **GPU** | **GPU** | GPU |
-| LM head | GPU | GPU | GPU | GPU | GPU |
+| LM head | GPU | NPU | GPU | GPU | GPU |
 
 ## Architecture
 

--- a/examples/gpt2/gpt2_inference.py
+++ b/examples/gpt2/gpt2_inference.py
@@ -50,14 +50,35 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 logger = logging.getLogger(__name__)
 
+# run_tests.py grades this exit code as a skip, not a failure -- the autotools
+# convention. Used when the environment cannot run the example (no transformers,
+# or the HuggingFace hub is unreachable) rather than when it has found a defect.
+SKIP_EXIT_CODE = 77
+
+
+class ExampleUnavailable(Exception):
+    """The example cannot run here (missing dependency or model download)."""
+
 
 def load_hf_model(hf_name="gpt2"):
-    """Load HuggingFace GPT-2 model and tokenizer."""
-    from transformers import AutoModelForCausalLM, AutoTokenizer
+    """Load HuggingFace GPT-2 model and tokenizer.
+
+    Raises ExampleUnavailable when transformers is not installed or the model
+    cannot be fetched, so a runner without them (CI without network / the HF
+    stack) skips rather than fails.
+    """
+    try:
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+    except ImportError as e:
+        raise ExampleUnavailable(f"transformers not installed: {e}") from e
 
     logger.info(f"Loading HuggingFace model: {hf_name}...")
-    tokenizer = AutoTokenizer.from_pretrained(hf_name)
-    hf_model = AutoModelForCausalLM.from_pretrained(hf_name)
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(hf_name)
+        hf_model = AutoModelForCausalLM.from_pretrained(hf_name)
+    except (OSError, ValueError) as e:
+        # HuggingFace raises OSError for an unreachable hub / missing cache.
+        raise ExampleUnavailable(f"could not load '{hf_name}': {e}") from e
     hf_model.eval()
     logger.info("HuggingFace model loaded.")
     return hf_model, tokenizer
@@ -156,7 +177,7 @@ def compare_logits(ref_logits, triton_logits, tokenizer, input_ids):
     print(f"  Top-5 overlap: {top5_overlap}/5")
     print("=" * 60)
 
-    return max_diff, mean_diff, top1_match
+    return max_diff, mean_diff, top1_match, cos_sim
 
 
 def print_generation(logits, tokenizer, input_ids, prompt):
@@ -378,9 +399,12 @@ def main():
     parser.add_argument(
         "--backend",
         type=str,
-        default="gpu",
+        # Defaults to npu: this is the NPU backend's example, and run_tests.py
+        # invokes it with no args to exercise the iGPU-free path. Pass --backend
+        # gpu/hetero explicitly for the other modes.
+        default="npu",
         choices=["gpu", "npu", "hetero", "hetero-fast", "reference"],
-        help="Backend: gpu, npu, hetero (consistent NPU/GPU split), hetero-fast (GPU-only decode), reference (HF only)",
+        help="Backend: npu (default), gpu, hetero (NPU/GPU split), hetero-fast (GPU-only decode), reference (HF only)",
     )
     parser.add_argument(
         "--prompt",
@@ -391,6 +415,9 @@ def main():
     parser.add_argument(
         "--max-tokens",
         type=int,
+        # Defaults to 0: the single-forward path asserts the logits match the
+        # HuggingFace reference (the correctness gate run_tests relies on); the
+        # generation path (>0) only prints text and cannot fail on wrong output.
         default=0,
         help="Number of tokens to generate (0 = single forward pass only)",
     )
@@ -472,11 +499,36 @@ def main():
         print_generation(triton_logits, tokenizer, input_ids, args.prompt)
 
         # Compare
-        compare_logits(ref_logits, triton_logits, tokenizer, input_ids)
+        _, _, top1_match, cos_sim = compare_logits(
+            ref_logits, triton_logits, tokenizer, input_ids
+        )
+        # Assert on what greedy decode depends on -- the top-1 token -- plus a
+        # cosine floor for gross corruption. bf16 rounding shifts exact logits
+        # but not these. A non-zero exit makes run_tests grade it FAIL.
+        COS_MIN = 0.99
+        if not top1_match or cos_sim < COS_MIN:
+            print(
+                f"CORRECTNESS FAILURE: top1_match={top1_match}, "
+                f"cosine={cos_sim:.6f} (min {COS_MIN})"
+            )
+            sys.exit(1)
 
 
 if __name__ == "__main__":
-    main()
+    # Exit code chosen here, then os._exit to skip interpreter finalization --
+    # see the teardown note below. Default 0; a SKIP or correctness failure
+    # overrides it.
+    _exit_code = 0
+    try:
+        main()
+    except ExampleUnavailable as e:
+        print(f"SKIP: {e}")
+        _exit_code = SKIP_EXIT_CODE
+    except SystemExit as e:
+        # main() calls sys.exit(1) on a correctness failure; carry the code out
+        # through the same os._exit path rather than letting the teardown fault
+        # (below) turn a clean FAIL into a crash.
+        _exit_code = e.code if isinstance(e.code, int) else 1
     # Backstop for the XRT/ROCm process-global teardown fault: results are fully
     # computed and printed by now, so skip interpreter finalization (C++ static
     # destructors) entirely. Flush first since os._exit does not. NPU resources
@@ -484,4 +536,4 @@ if __name__ == "__main__":
     # only guards the residual global-teardown crash GC ordering cannot reach.
     sys.stdout.flush()
     sys.stderr.flush()
-    os._exit(0)
+    os._exit(_exit_code)

--- a/examples/gpt2/kernels/backend_utils.py
+++ b/examples/gpt2/kernels/backend_utils.py
@@ -9,14 +9,21 @@ from contextlib import contextmanager
 
 @contextmanager
 def npu_driver_scope():
-    """Temporarily activate NPU driver for a kernel launch, then restore."""
+    """Temporarily activate NPU driver for a kernel launch, then restore.
+
+    Restores the driver active on entry rather than ``reset_active()``, which
+    resolves the auto-detected default and fails with "0 active drivers" on an
+    iGPU-free host (CI without ROCm): npu mode sets NPUDriver explicitly, so no
+    GPU driver is auto-active to fall back to.
+    """
     from triton.backends.amd_triton_npu.driver import NPUDriver
 
+    prev = triton.runtime.driver.active
     triton.runtime.driver.set_active(NPUDriver())
     try:
         yield
     finally:
-        triton.runtime.driver.reset_active()
+        triton.runtime.driver.set_active(prev)
 
 
 class CachedNPUKernel:

--- a/examples/gpt2/model.py
+++ b/examples/gpt2/model.py
@@ -462,9 +462,7 @@ class _FusedMLP:
             b_proj_np = b_proj.to(torch.float32).cpu().numpy()
             # Only the on-GPU output path uses this; skip it (no cuda) when the
             # buffers are XRT-only.
-            b_proj_dev = (
-                torch.from_numpy(b_proj_np).to("cuda") if self._share else None
-            )
+            b_proj_dev = torch.from_numpy(b_proj_np).to("cuda") if self._share else None
             self._weights[layer_idx] = (B0, B2, b_proj_np, b_proj_dev)
         return self._weights[layer_idx]
 
@@ -1306,9 +1304,7 @@ class GPT2Model:
                         transform_script=self.matmul_script,
                     ).reshape(x.shape[:-1] + (VOCAB_SIZE,))
                 except Exception as e:
-                    logger.warning(
-                        f"NPU LM head unavailable ({e}); using a CPU matmul"
-                    )
+                    logger.warning(f"NPU LM head unavailable ({e}); using a CPU matmul")
                     logits = (x2d @ self.wte.to(torch.float32).t()).reshape(
                         x.shape[:-1] + (VOCAB_SIZE,)
                     )

--- a/examples/gpt2/model.py
+++ b/examples/gpt2/model.py
@@ -166,13 +166,22 @@ class _FusedMLP:
     """
 
     def __init__(
-        self, n_embd, mlp_dim, matmul_script, gelu_f32in_script, add_f32_script
+        self,
+        n_embd,
+        mlp_dim,
+        matmul_script,
+        gelu_f32in_script,
+        add_f32_script,
+        share="hip:0",
     ):
         self.D = n_embd
         self.H = mlp_dim
         self.matmul_script = matmul_script
         self.gelu_script = gelu_f32in_script
         self.add_script = add_f32_script
+        # Secondary device the operand buffers map into: "hip:0" for hetero's
+        # zero-copy iGPU hand-off, () for npu mode (XRT-only, no ROCm dependency).
+        self._share = share
         self.BM = 128
         self.BN = 256
         self.K0_pad = _next_pow2(self.D + 1)  # +1 bias row
@@ -224,12 +233,13 @@ class _FusedMLP:
         """
         from triton.backends.amd_triton_npu import shared
 
-        # Allocated by XRT so the NPU can name the BO directly, then mapped into
-        # the iGPU. The BOs and the chain's dispatch end up on different
-        # pyxrt.device handles -- each opens its own -- which is fine: handles to
-        # the same device are interchangeable, and shared_buffer_test.py pins
-        # that down by dispatching cross-handle on every run.
-        on = dict(device="xrt:0", share=_IGPU)
+        # Allocated by XRT so the NPU can name the BO directly, and mapped into
+        # self._share when set (hetero's iGPU). The BOs and the chain's dispatch
+        # end up on different pyxrt.device handles -- fine, handles to the same
+        # device are interchangeable.
+        on = dict(device="xrt:0")
+        if self._share:
+            on["share"] = self._share
         # The augmented-K bias fold requires the padding columns past D+1 to be
         # zero, and column D to be 1.0. Both are invariant across every dispatch
         # and every layer, so they are written once here rather than per launch.
@@ -237,14 +247,20 @@ class _FusedMLP:
         self._sb_R = shared.zeros(self.BM, self.D, dtype=torch.float32, **on)
         self._sb_OUT = shared.zeros_like(self._sb_R)
         self._sb_A[:, self.D] = 1.0
-        torch.cuda.synchronize()
+        # Fence the iGPU fill before the NPU reads it. An XRT-only buffer's fill
+        # is host-side and needs no fence.
+        if self._share:
+            torch.cuda.synchronize()
         # Hold the torch views. SharedBuffer keeps them weakly, so that a
         # consumer's tensor can own its buffer without forming a cycle the
         # collector cannot see -- which means an unheld view is re-derived on
         # every access (~4 us against ~0.04 cached). run() touches all three
         # per layer, so holding them here is worth ~140 us per token.
         self._views = (self._sb_A.torch(), self._sb_R.torch(), self._sb_OUT.torch())
-        logger.info("zero-copy NPU/iGPU buffers enabled for the fused MLP")
+        logger.info(
+            "shared fused-MLP buffers enabled (%s)",
+            "zero-copy NPU/iGPU" if self._share else "XRT-only",
+        )
 
     def _build_kernels(self):
         import triton
@@ -444,9 +460,11 @@ class _FusedMLP:
         if layer_idx not in self._weights:
             B0, B2 = self._prep_weights(w_fc, b_fc, w_proj, b_proj)
             b_proj_np = b_proj.to(torch.float32).cpu().numpy()
-            # The iGPU copy rides in the same cache rather than a parallel one,
-            # so it is created and released with everything else for the layer.
-            b_proj_dev = torch.from_numpy(b_proj_np).to("cuda")
+            # Only the on-GPU output path uses this; skip it (no cuda) when the
+            # buffers are XRT-only.
+            b_proj_dev = (
+                torch.from_numpy(b_proj_np).to("cuda") if self._share else None
+            )
             self._weights[layer_idx] = (B0, B2, b_proj_np, b_proj_dev)
         return self._weights[layer_idx]
 
@@ -587,8 +605,9 @@ class GPT2Model:
             self._place_weights()
 
         # Cache wte on GPU for the LM head matmul (768x50257).
-        # On CPU this takes ~20ms; on GPU <1ms.
-        if backend in ("npu", "hetero", "hetero-fast"):
+        # On CPU this takes ~20ms; on GPU <1ms. hetero only -- npu mode runs the
+        # LM head on the NPU instead (see forward()), so it never touches cuda.
+        if backend in ("hetero", "hetero-fast"):
             self._wte_lm_head = self.wte.to(device="cuda", dtype=torch.float32)
         else:
             self._wte_lm_head = None
@@ -632,6 +651,8 @@ class GPT2Model:
                     self.matmul_script,
                     self.gelu_f32in_script,
                     self.add_f32_script,
+                    # iGPU-shared only in hetero; npu mode stays XRT-only (no ROCm).
+                    share="hip:0" if self._is_hetero else (),
                 )
             except (SharedBufferError, ImportError) as e:
                 # The fused chain needs buffers both devices can address. Where
@@ -1267,10 +1288,30 @@ class GPT2Model:
         # genuinely need host logits should say so explicitly.
         with self.timer.track("lm_head"):
             if self._wte_lm_head is not None:
-                # NPU/hetero: run on GPU (~0.5ms vs ~20ms on CPU)
+                # hetero: run on the iGPU (~0.5ms vs ~20ms on CPU), where x is.
                 logits = (
                     x.to(device="cuda", dtype=torch.float32) @ self._wte_lm_head.t()
                 )
+            elif self.backend == "npu":
+                # LM head on the NPU keeps the forward iGPU-free. triton_linear
+                # transposes internally, so pass wte (vocab, n_embd) directly --
+                # not via self._linear, which would transpose a second time. CPU
+                # fallback (never cuda) if the vocab-sized matmul won't lower.
+                x2d = x.reshape(-1, self.n_embd).to(torch.float32)
+                try:
+                    logits = triton_linear(
+                        x2d,
+                        self.wte,
+                        backend="npu",
+                        transform_script=self.matmul_script,
+                    ).reshape(x.shape[:-1] + (VOCAB_SIZE,))
+                except Exception as e:
+                    logger.warning(
+                        f"NPU LM head unavailable ({e}); using a CPU matmul"
+                    )
+                    logits = (x2d @ self.wte.to(torch.float32).t()).reshape(
+                        x.shape[:-1] + (VOCAB_SIZE,)
+                    )
             else:
                 # GPU: x and wte already on CUDA
                 logits = x.to(torch.float32) @ self.wte.to(torch.float32).t()

--- a/examples/qwen2_5/README.md
+++ b/examples/qwen2_5/README.md
@@ -15,17 +15,18 @@ scripts serve every size:
 
 ## Setup
 
-**Prerequisite: a ROCm torch device is required for all backends except
-`reference`.** Every mode — including `--backend npu` — runs attention (Q/K/V/O
-projections, RoPE, the fused grouped-query attention kernel) and the LM head on
-the iGPU (see the routing table below), so a working ROCm/Triton GPU with a
-ROCm build of PyTorch must be installed.
+**`--backend npu` runs on the NPU and CPU only — no iGPU, so it needs neither a
+ROCm GPU nor a ROCm build of PyTorch.** The `gpu`, `hetero`, and `hetero-fast`
+modes do require a ROCm torch device; `reference` needs neither. See the routing
+table below.
 
 ```bash
 # Prerequisites
 pip install transformers
-# ROCm PyTorch (adjust the ROCm version to match your install)
-pip install torch --index-url https://download.pytorch.org/whl/rocm6.2
+# torch: a CPU build is enough for `npu` and `reference`; use a ROCm build for
+# the gpu/hetero modes (adjust the ROCm version to match your install).
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+# pip install torch --index-url https://download.pytorch.org/whl/rocm6.2
 
 # Environment setup (required for NPU/hetero modes)
 source /opt/xilinx/xrt/setup.sh
@@ -67,19 +68,27 @@ Four backends route operators across devices differently:
 | Backend | Description |
 |---------|-------------|
 | `gpu` | All ops on iGPU via ROCm/Triton |
-| `npu` | RMSNorm/MLP/add on NPU; attention and LM head on iGPU |
+| `npu` | NPU + CPU only, no iGPU: RMSNorm/MLP/add and the Q/K/V/O projections on the NPU, the attention core (RoPE, scores, softmax, attn·V) and the LM head on CPU |
 | `hetero` | Attention on GPU, RMSNorm/MLP/add on NPU |
 | `hetero-fast` | Same as hetero for prefill; all-GPU decode |
 
 ### Per-Op Device Routing
 
+In `gpu`/`hetero`/`hetero-fast`, attention is one fused GPU kernel. In `npu` it
+is split: the Q/K/V/O projections run on the NPU and the RoPE/scores/softmax/
+attn·V core on CPU (there is no NPU attention kernel yet), so those rows are
+broken out below. Qwen's larger vocab makes its LM head run on CPU (gpt2's runs
+on the NPU) — a vocab-sized NPU matmul is far slower there than on the CPU.
+
 | Op | `gpu` | `npu` | `hetero` | `hetero-fast` prefill | `hetero-fast` decode |
 |----|-------|-------|----------|----------------------|---------------------|
 | RMSNorm (input) | GPU | NPU | NPU | NPU | **GPU** |
-| Q/K/V projection | GPU | GPU | GPU | GPU | GPU |
-| RoPE | GPU | GPU | GPU | GPU | GPU |
-| Fused attention (GQA) | GPU | GPU | GPU | GPU | GPU |
-| Output projection | GPU | GPU | GPU | GPU | GPU |
+| Q/K/V projection | GPU | NPU | GPU | GPU | GPU |
+| RoPE | GPU | CPU | GPU (fused) | GPU (fused) | GPU (fused) |
+| Attention scores (Q·Kᵀ) | GPU (fused) | CPU | GPU (fused) | GPU (fused) | GPU (fused) |
+| Softmax | GPU (fused) | CPU | GPU (fused) | GPU (fused) | GPU (fused) |
+| Attention · V | GPU (fused) | CPU | GPU (fused) | GPU (fused) | GPU (fused) |
+| Output projection | GPU | NPU | GPU | GPU | GPU |
 | Residual add | GPU | NPU | NPU | NPU | **GPU** |
 | RMSNorm (post-attn) | GPU | NPU | NPU | NPU | **GPU** |
 | MLP gate/up proj | GPU | NPU | NPU | NPU | **GPU** |
@@ -87,7 +96,7 @@ Four backends route operators across devices differently:
 | MLP down proj | GPU | NPU | NPU | NPU | **GPU** |
 | Residual add | GPU | NPU | NPU | NPU | **GPU** |
 | Final RMSNorm | GPU | NPU | NPU | NPU | **GPU** |
-| LM head | GPU | GPU | GPU | GPU | GPU |
+| LM head | GPU | CPU | GPU | GPU | GPU |
 
 Attention (Q/K/V/O, RoPE, the fused attention kernel) always runs on the iGPU:
 the fused FlashAttention-style kernel is GPU-only, and Qwen's grouped-query

--- a/examples/qwen2_5/kernels/backend_utils.py
+++ b/examples/qwen2_5/kernels/backend_utils.py
@@ -9,14 +9,21 @@ from contextlib import contextmanager
 
 @contextmanager
 def npu_driver_scope():
-    """Temporarily activate NPU driver for a kernel launch, then restore."""
+    """Temporarily activate NPU driver for a kernel launch, then restore.
+
+    Restores the driver active on entry rather than ``reset_active()``, which
+    resolves the auto-detected default and fails with "0 active drivers" on an
+    iGPU-free host (CI without ROCm): npu mode sets NPUDriver explicitly, so no
+    GPU driver is auto-active to fall back to.
+    """
     from triton.backends.amd_triton_npu.driver import NPUDriver
 
+    prev = triton.runtime.driver.active
     triton.runtime.driver.set_active(NPUDriver())
     try:
         yield
     finally:
-        triton.runtime.driver.reset_active()
+        triton.runtime.driver.set_active(prev)
 
 
 class CachedNPUKernel:

--- a/examples/qwen2_5/model.py
+++ b/examples/qwen2_5/model.py
@@ -909,12 +909,8 @@ class Qwen2Model:
             attn_output = torch.matmul(attn_weights, v_f)
         else:
             q_3d = q.reshape(B * self.n_head, S, self.head_dim).contiguous()
-            k_3d = k_exp.reshape(
-                B * self.n_head, total_len, self.head_dim
-            ).contiguous()
-            v_3d = v_exp.reshape(
-                B * self.n_head, total_len, self.head_dim
-            ).contiguous()
+            k_3d = k_exp.reshape(B * self.n_head, total_len, self.head_dim).contiguous()
+            v_3d = v_exp.reshape(B * self.n_head, total_len, self.head_dim).contiguous()
             is_causal = S > 1
             attn_output = triton_fused_attention(
                 q_3d,

--- a/examples/qwen2_5/model.py
+++ b/examples/qwen2_5/model.py
@@ -1131,24 +1131,15 @@ class Qwen2Model:
                     x.to(device="cuda", dtype=torch.float32) @ self._lm_head.t()
                 ).cpu()
             elif self.backend == "npu":
-                # LM head on the NPU keeps the forward iGPU-free. embed_tokens
-                # (vocab, n_embd) is the weight shape triton_linear expects. CPU
-                # fallback (never cuda) if the vocab-sized matmul won't lower.
+                # LM head on CPU keeps npu mode iGPU-free without paying the NPU
+                # cost of the vocab-151936 matmul: a single [M,896]@[896,151936]
+                # runs ~29s/token on the AIE (73% of decode) but ~20ms on the
+                # CPU. gpt2's smaller vocab makes the NPU LM head worthwhile; this
+                # one does not.
                 x2d = x.reshape(-1, self.n_embd).to(torch.float32)
-                try:
-                    logits = triton_linear(
-                        x2d,
-                        self.embed_tokens,
-                        backend="npu",
-                        transform_script=self.matmul_script,
-                    ).reshape(x.shape[:-1] + (VOCAB_SIZE,))
-                except Exception as e:
-                    logger.warning(
-                        f"NPU LM head unavailable ({e}); using a CPU matmul"
-                    )
-                    logits = (x2d @ self.embed_tokens.to(torch.float32).t()).reshape(
-                        x.shape[:-1] + (VOCAB_SIZE,)
-                    )
+                logits = (x2d @ self.embed_tokens.to(torch.float32).t()).reshape(
+                    x.shape[:-1] + (VOCAB_SIZE,)
+                )
             else:
                 logits = x.to(torch.float32) @ self.embed_tokens.to(torch.float32).t()
                 if logits.device.type == "cuda":

--- a/examples/qwen2_5/model.py
+++ b/examples/qwen2_5/model.py
@@ -17,8 +17,8 @@ model sizes (0.5B, 1.5B); select one with the --model CLI flag.
 
 Four backends route operators across iGPU and NPU:
   "gpu":         all ops on iGPU via ROCm/Triton
-  "npu":         all ops on NPU via MLIR-AIR/AIE (attention falls back to GPU
-                 fused kernel, matching the gpt2 example)
+  "npu":         all ops on NPU via MLIR-AIR/AIE; no iGPU. Attention's
+                 scaled-dot-product core runs on CPU (no NPU kernel yet)
   "hetero":      attention on iGPU; RMSNorm/MLP/add on NPU (prefill & decode)
   "hetero-fast": same as hetero for prefill; all-GPU decode (lower TPOT)
 
@@ -606,8 +606,10 @@ class Qwen2Model:
         elif backend == "hetero":
             self._place_weights()
 
-        # LM head matmul (tied to embeddings). Cache on GPU for speed.
-        if backend in ("npu", "hetero", "hetero-fast"):
+        # LM head matmul (tied to embeddings). Cache on GPU for speed in hetero;
+        # npu mode runs it on the NPU instead (see forward()) so it never touches
+        # cuda.
+        if backend in ("hetero", "hetero-fast"):
             self._lm_head = self.embed_tokens.to(device="cuda", dtype=torch.float32)
         else:
             self._lm_head = None
@@ -824,14 +826,21 @@ class Qwen2Model:
     def _attention(self, x, layer, kv_cache=None, pos_offset=0):
         """Multi-head GQA self-attention with RoPE and optional KV cache.
 
-        x arrives on CUDA in every backend; all attention ops run on GPU.
+        In gpu/hetero modes attention runs on the iGPU via the fused kernel. In
+        npu mode there is no NPU attention kernel yet, so qkv/o_proj run on the
+        NPU and the scaled-dot-product core (RoPE, scores, softmax, attn@V) runs
+        on CPU float32, keeping npu mode off the iGPU.
         """
         B, S, D = x.shape
 
-        # Attention runs on GPU in every backend (the fused kernel is GPU-only and
-        # there is no NPU attention path), so the qkv/o_proj matmuls must too
-        attn_be = self.op_backend["qkv_linear"] if self.op_backend else "gpu"
-        proj_be = self.op_backend["attn_proj"] if self.op_backend else "gpu"
+        npu = self.backend == "npu"
+        # qkv/o_proj on the NPU in npu mode, else the iGPU (the fused kernel is
+        # GPU-only). op_backend, set only in hetero, overrides both.
+        if self.op_backend:
+            attn_be = self.op_backend["qkv_linear"]
+            proj_be = self.op_backend["attn_proj"]
+        else:
+            attn_be = proj_be = "npu" if npu else "gpu"
 
         # Fused QKV projection: q/k/v share input x, so concat their weights and
         # biases into one (n_head+2*n_kv_head)*hd linear -> one GPU launch instead
@@ -882,18 +891,39 @@ class Qwen2Model:
             v_exp = v_full
 
         scale = 1.0 / math.sqrt(self.head_dim)
-        q_3d = q.reshape(B * self.n_head, S, self.head_dim).contiguous()
-        k_3d = k_exp.reshape(B * self.n_head, total_len, self.head_dim).contiguous()
-        v_3d = v_exp.reshape(B * self.n_head, total_len, self.head_dim).contiguous()
-        is_causal = S > 1
-        attn_output = triton_fused_attention(
-            q_3d,
-            k_3d,
-            v_3d,
-            scale=scale,
-            causal=is_causal,
-            pos_offset=pos_offset,
-        ).reshape(B, self.n_head, S, self.head_dim)
+        if npu:
+            # CPU scaled-dot-product attention in float32 (no NPU attention
+            # kernel yet). q/k/v are already CPU tensors from the NPU qkv linear.
+            q_f = q.to(torch.float32)
+            k_f = k_exp.to(torch.float32)
+            v_f = v_exp.to(torch.float32)
+            scores = torch.matmul(q_f, k_f.transpose(-2, -1)) * scale
+            if S > 1:
+                # Causal mask over the current block against all past positions.
+                rows = torch.arange(S).unsqueeze(1) + pos_offset
+                cols = torch.arange(total_len).unsqueeze(0)
+                scores = scores.masked_fill(
+                    (cols > rows).unsqueeze(0).unsqueeze(0), float("-inf")
+                )
+            attn_weights = torch.softmax(scores, dim=-1)
+            attn_output = torch.matmul(attn_weights, v_f)
+        else:
+            q_3d = q.reshape(B * self.n_head, S, self.head_dim).contiguous()
+            k_3d = k_exp.reshape(
+                B * self.n_head, total_len, self.head_dim
+            ).contiguous()
+            v_3d = v_exp.reshape(
+                B * self.n_head, total_len, self.head_dim
+            ).contiguous()
+            is_causal = S > 1
+            attn_output = triton_fused_attention(
+                q_3d,
+                k_3d,
+                v_3d,
+                scale=scale,
+                causal=is_causal,
+                pos_offset=pos_offset,
+            ).reshape(B, self.n_head, S, self.head_dim)
 
         attn_output = attn_output.transpose(1, 2).reshape(B, S, self.n_embd)
 
@@ -1100,6 +1130,25 @@ class Qwen2Model:
                 logits = (
                     x.to(device="cuda", dtype=torch.float32) @ self._lm_head.t()
                 ).cpu()
+            elif self.backend == "npu":
+                # LM head on the NPU keeps the forward iGPU-free. embed_tokens
+                # (vocab, n_embd) is the weight shape triton_linear expects. CPU
+                # fallback (never cuda) if the vocab-sized matmul won't lower.
+                x2d = x.reshape(-1, self.n_embd).to(torch.float32)
+                try:
+                    logits = triton_linear(
+                        x2d,
+                        self.embed_tokens,
+                        backend="npu",
+                        transform_script=self.matmul_script,
+                    ).reshape(x.shape[:-1] + (VOCAB_SIZE,))
+                except Exception as e:
+                    logger.warning(
+                        f"NPU LM head unavailable ({e}); using a CPU matmul"
+                    )
+                    logits = (x2d @ self.embed_tokens.to(torch.float32).t()).reshape(
+                        x.shape[:-1] + (VOCAB_SIZE,)
+                    )
             else:
                 logits = x.to(torch.float32) @ self.embed_tokens.to(torch.float32).t()
                 if logits.device.type == "cuda":

--- a/examples/qwen2_5/qwen_inference.py
+++ b/examples/qwen2_5/qwen_inference.py
@@ -69,7 +69,13 @@ def run_triton_model(state_dict, input_ids, backend, profile=False, config=None)
 
     import benchmark
 
-    benchmark.select_gpu_backend()
+    # npu mode activates the NPU driver directly. select_gpu_backend() calls
+    # reset_active(), which needs an auto-active GPU driver -- absent on an
+    # iGPU-free host -- so npu mode must not take that path.
+    if backend == "npu":
+        benchmark.select_npu_backend()
+    else:
+        benchmark.select_gpu_backend()
 
     model = Qwen2Model(state_dict, backend=backend, config=config)
     model.timer.enabled = profile
@@ -142,7 +148,12 @@ def run_generation(hf_model, tokenizer, input_ids, args):
 
     import benchmark
 
-    benchmark.select_gpu_backend()
+    # See run_triton_model: npu mode activates the NPU driver rather than
+    # reset_active()-ing to a GPU default that an iGPU-free host does not have.
+    if args.backend == "npu":
+        benchmark.select_npu_backend()
+    else:
+        benchmark.select_gpu_backend()
 
     state_dict = hf_model.state_dict()
     model = Qwen2Model(
@@ -218,7 +229,12 @@ def run_interactive(hf_model, tokenizer, args):
 
     import benchmark
 
-    benchmark.select_gpu_backend()
+    # See run_triton_model: npu mode activates the NPU driver rather than
+    # reset_active()-ing to a GPU default that an iGPU-free host does not have.
+    if backend == "npu":
+        benchmark.select_npu_backend()
+    else:
+        benchmark.select_gpu_backend()
 
     state_dict = hf_model.state_dict()
     model = Qwen2Model(

--- a/examples/qwen2_5/qwen_inference.py
+++ b/examples/qwen2_5/qwen_inference.py
@@ -33,14 +33,37 @@ from model import QWEN_CONFIGS
 
 logger = logging.getLogger(__name__)
 
+# run_tests.py grades this exit code as a skip, not a failure -- the autotools
+# convention. Used when the environment cannot run the example (no transformers,
+# or the HuggingFace hub is unreachable) rather than when it has found a defect.
+SKIP_EXIT_CODE = 77
+
+
+class ExampleUnavailable(Exception):
+    """The example cannot run here (missing dependency or model download)."""
+
 
 def load_hf_model(hf_name="Qwen/Qwen2.5-0.5B-Instruct"):
-    from transformers import AutoModelForCausalLM, AutoTokenizer
+    """Load a HuggingFace Qwen model and tokenizer.
+
+    Raises ExampleUnavailable when transformers is not installed or the model
+    cannot be fetched, so a runner without them (CI without network / the HF
+    stack) skips rather than fails.
+    """
+    try:
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+    except ImportError as e:
+        raise ExampleUnavailable(f"transformers not installed: {e}") from e
 
     name = hf_name
     logger.info(f"Loading HuggingFace model {name}...")
-    tokenizer = AutoTokenizer.from_pretrained(name)
-    hf_model = AutoModelForCausalLM.from_pretrained(name, torch_dtype=torch.float32)
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(name)
+        hf_model = AutoModelForCausalLM.from_pretrained(
+            name, torch_dtype=torch.float32
+        )
+    except (OSError, ValueError) as e:
+        raise ExampleUnavailable(f"could not load '{name}': {e}") from e
     hf_model.eval()
     logger.info("HuggingFace model loaded.")
     return hf_model, tokenizer
@@ -132,7 +155,7 @@ def compare_logits(ref_logits, triton_logits, tokenizer):
     print(f"\n  Top-1 match: {'YES' if top1_match else 'NO'}")
     print(f"  Top-5 overlap: {top5_overlap}/5")
     print("=" * 60)
-    return max_diff, mean_diff, top1_match
+    return max_diff, mean_diff, top1_match, cos_sim
 
 
 def print_generation(logits, tokenizer, prompt):
@@ -336,7 +359,10 @@ def main():
     parser.add_argument(
         "--backend",
         type=str,
-        default="gpu",
+        # Defaults to npu: this is the NPU backend's example, and run_tests.py
+        # invokes it with no args to exercise the iGPU-free path. Pass --backend
+        # gpu/hetero explicitly for the other modes.
+        default="npu",
         choices=["gpu", "npu", "hetero", "hetero-fast", "reference"],
     )
     parser.add_argument(
@@ -344,7 +370,14 @@ def main():
         type=str,
         default="Give me a short introduction to large language models.",
     )
-    parser.add_argument("--max-tokens", type=int, default=0)
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        # Defaults to 0: the single-forward path asserts the logits match the
+        # HuggingFace reference (the correctness gate run_tests relies on); the
+        # generation path (>0) only prints text and cannot fail on wrong output.
+        default=0,
+    )
     parser.add_argument("--interactive", action="store_true")
     parser.add_argument("--profile", action="store_true")
     parser.add_argument(
@@ -398,14 +431,38 @@ def main():
         )
         print(f"\n--- Triton ({args.backend.upper()}) ---")
         print_generation(triton_logits, tokenizer, args.prompt)
-        compare_logits(ref_logits, triton_logits, tokenizer)
+        _, _, top1_match, cos_sim = compare_logits(
+            ref_logits, triton_logits, tokenizer
+        )
+        # Cosine floor only, no top-1: qwen's all-NPU forward has a known ~0.97
+        # accuracy gap vs the fp32 reference (rmsnorm bf16 numerics, see
+        # OPTIMIZATIONS.md) that legitimately flips the top-1 token, so a top-1
+        # assert would fail on a known limitation, not a regression. Raise the
+        # floor and re-add top-1 once the rmsnorm-numerics lever lands.
+        COS_MIN = 0.95
+        if cos_sim < COS_MIN:
+            print(f"CORRECTNESS FAILURE: cosine={cos_sim:.6f} (min {COS_MIN})")
+            sys.exit(1)
 
 
 if __name__ == "__main__":
-    main()
+    # Exit code chosen here, then os._exit to skip interpreter finalization --
+    # see the teardown note below. Default 0; a SKIP or correctness failure
+    # overrides it.
+    _exit_code = 0
+    try:
+        main()
+    except ExampleUnavailable as e:
+        print(f"SKIP: {e}")
+        _exit_code = SKIP_EXIT_CODE
+    except SystemExit as e:
+        # main() calls sys.exit(1) on a correctness failure; carry the code out
+        # through the same os._exit path rather than letting the teardown fault
+        # (below) turn a clean FAIL into a crash.
+        _exit_code = e.code if isinstance(e.code, int) else 1
     # Backstop for the XRT/ROCm process-global teardown fault: results are fully
     # computed and printed by now, so skip interpreter finalization (C++ static
     # destructors) entirely. Flush first since os._exit does not.
     sys.stdout.flush()
     sys.stderr.flush()
-    os._exit(0)
+    os._exit(_exit_code)

--- a/examples/qwen2_5/qwen_inference.py
+++ b/examples/qwen2_5/qwen_inference.py
@@ -59,9 +59,7 @@ def load_hf_model(hf_name="Qwen/Qwen2.5-0.5B-Instruct"):
     logger.info(f"Loading HuggingFace model {name}...")
     try:
         tokenizer = AutoTokenizer.from_pretrained(name)
-        hf_model = AutoModelForCausalLM.from_pretrained(
-            name, torch_dtype=torch.float32
-        )
+        hf_model = AutoModelForCausalLM.from_pretrained(name, torch_dtype=torch.float32)
     except (OSError, ValueError) as e:
         raise ExampleUnavailable(f"could not load '{name}': {e}") from e
     hf_model.eval()
@@ -431,9 +429,7 @@ def main():
         )
         print(f"\n--- Triton ({args.backend.upper()}) ---")
         print_generation(triton_logits, tokenizer, args.prompt)
-        _, _, top1_match, cos_sim = compare_logits(
-            ref_logits, triton_logits, tokenizer
-        )
+        _, _, top1_match, cos_sim = compare_logits(ref_logits, triton_logits, tokenizer)
         # Cosine floor only, no top-1: qwen's all-NPU forward has a known ~0.97
         # accuracy gap vs the fp32 reference (rmsnorm bf16 numerics, see
         # OPTIMIZATIONS.md) that legitimately flips the top-1 token, so a top-1

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -22,6 +22,11 @@ DEFAULT_SKIPPED_EXAMPLES = {
     "layernorm",
     "load_2d_block",
     "multi_drivers",
+    # LLM end-to-end examples: heavy (HuggingFace download + long compiles). CI
+    # runs them explicitly (-t gpt2 -t qwen2_5) in a dedicated step, so keep them
+    # out of the default sweep.
+    "gpt2",
+    "qwen2_5",
 }
 
 # Examples that cannot run without a transform script on a given device, keyed
@@ -76,9 +81,17 @@ def discover_example_dirs(examples_dir: Path, selected: list[str]) -> list[Path]
 
 def discover_python_files(example_dir: Path) -> list[Path]:
     """
-    Return a list of .py files directly under example_dir (non-recursive).
+    Return the .py files to run directly under example_dir (non-recursive).
+
+    When a directory ships an ``*_inference.py`` entry point, run only those:
+    the LLM examples (gpt2, qwen2_5) also contain a ``model.py`` library with no
+    ``__main__``, which would otherwise be "run" as a no-op that passes without
+    testing anything -- and double-count the directory. Directories without an
+    inference entry point keep the original behavior (every .py runs).
     """
-    return sorted([p for p in example_dir.glob("*.py") if p.is_file()])
+    py_files = sorted([p for p in example_dir.glob("*.py") if p.is_file()])
+    inference = [p for p in py_files if p.name.endswith("_inference.py")]
+    return inference or py_files
 
 
 def run_python_file(


### PR DESCRIPTION
## Make gpt2/qwen `--backend npu` run without the iGPU, and gate it in CI

  ### Why

  `--backend npu` for the gpt2 and qwen2.5 examples pulled in the iGPU (ROCm/HIP) even though it should need only the NPU (plus CPU where no NPU kernel exists). That blocked running npu mode in CI on a clean NPU-only runner, and
  made "NPU" mode quietly depend on a ROCm PyTorch install. This PR removes the iGPU dependency from npu mode and wires the two examples into CI as an end-to-end, iGPU-free correctness gate.

  ### The core fix: driver restoration

  The main blocker wasn't the model code — it was driver handling. `set_active(NPUDriver())` followed by `reset_active()` resolves Triton's *auto-detected* default driver, which requires exactly one auto-active driver (normally the
  iGPU's). On an iGPU-free host that fails with `RuntimeError: 0 active drivers`. Every such site now restores the driver that was active on entry instead:
  - `amd_triton_npu/backend/multilaunch.py` — `_capture_ttshared` (the fused-MLP warmup path; only shipped-backend file touched)
  - `examples/{gpt2,qwen2_5}/kernels/backend_utils.py` — `npu_driver_scope` (per-op dispatch)
  - `examples/qwen2_5/qwen_inference.py` — gated its unconditional `select_gpu_backend()` calls by backend, matching gpt2

  ### Per-model changes

  **gpt2**
  - LM head runs on the NPU instead of a cuda cache (CPU fallback if the vocab matmul won't lower).
  - Fused MLP takes a `share=` argument so npu mode allocates XRT-only buffers (no HIP); hetero keeps its zero-copy iGPU hand-off unchanged.

  **qwen**
  - Attention gains an npu path: Q/K/V/O projections on the NPU, the scaled-dot-product core (RoPE, scores, softmax, attn·V) on CPU float32 (there is no NPU attention kernel yet).
  - LM head runs on CPU — its vocab-151936 matmul runs ~29 s/token on the AIE (73% of decode) vs ~20 ms on the CPU, and is iGPU-free either way.

  ### CI gate

  - npu is now the default `--backend` for both example scripts, so `run_tests.py` (which invokes with no args) runs them in npu mode.
  - A dedicated CI step runs `-t gpt2 -t qwen2_5` with `CUDA/HIP/ROCR_VISIBLE_DEVICES=""`, so a stray cuda/HIP touch **fails the job** rather than silently using the iGPU. It installs the CPU-only runtime deps (`transformers numpy
  ml_dtypes`).
  - `run_tests.py` now runs only `*_inference.py` when a dir ships one (the LLM `model.py` is a library with no `__main__` and was a no-op "pass"), and skips gpt2/qwen in the default sweep since the dedicated step runs them
  explicitly.
  - The single-forward path (`--max-tokens 0`, default) now **asserts** the Triton logits match the HuggingFace reference: gpt2 strictly (top-1 token and cosine ≥ 0.99); qwen on a cosine floor only (≥ 0.95), because its all-NPU
  forward has a known ~0.97 accuracy gap (rmsnorm bf16 numerics) that legitimately flips the top-1 token.
  - Missing `transformers` / an unreachable HuggingFace hub exits `77` → graded **SKIP**, not FAIL, so a runner without those stays green.

  ### Verification

  `run_tests.py -t gpt2 -t qwen2_5 --device aie2p` with the iGPU hidden → **2/2 pass**, logit checks enforced, no cuda/HIP touch. gpt2 hetero warm TPOT unchanged (~40 ms), confirming the `share=` threading didn't regress the
  fused-MLP fast path. Full default suite stays green (real examples).

  ### Docs

  Updated both example READMEs: npu mode no longer requires a ROCm GPU or ROCm torch (a CPU torch build suffices), and the per-op routing tables now reflect the NPU+CPU split (also correcting a pre-existing row that showed gpt2's
  npu attention as fully NPU).