### PR TITLE
ci: run gpt2/qwen hetero examples on the iGPU

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -38,6 +38,7 @@ runs:
       pip install --no-cache-dir --upgrade pip setuptools wheel
       pip install --no-cache-dir lit cmake joblib pybind11 nanobind
       pip3 install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.14
+      pip3 uninstall -y triton-rocm pytorch-triton-rocm
 
    - name: Install MLIR-AIR (with mlir-aie + llvm-aie via [aie] extra)
      env:

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -37,7 +37,7 @@ runs:
       source ${{ inputs.env_name }}/bin/activate
       pip install --no-cache-dir --upgrade pip setuptools wheel
       pip install --no-cache-dir lit cmake joblib pybind11 nanobind
-      pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+      pip3 install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.14
 
    - name: Install MLIR-AIR (with mlir-aie + llvm-aie via [aie] extra)
      env:

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -156,6 +156,30 @@ runs:
 
         echo ""
         echo "=========================================="
+        echo "STEP 7b: ROCm torch diagnostic probe"
+        echo "=========================================="
+        # Every example segfaults (exit -11) at import with no traceback; narrow
+        # down where ROCm torch dies. Each probe is non-fatal (|| echo) so we see
+        # all of them in one run. Order matters: the examples import torch before
+        # triton, so replicate that too.
+        echo "--- probe 1: bare torch import ---"
+        python -c "import torch; print('torch import ok', torch.__version__)" \
+          || echo "PROBE FAIL: bare torch import rc=$?"
+        echo "--- probe 2: torch then triton (example import order) ---"
+        python -c "import torch; import triton; from triton.backends.amd_triton_npu.driver import NPUDriver; print('torch+triton import ok')" \
+          || echo "PROBE FAIL: torch+triton import rc=$?"
+        echo "--- probe 3: HIP device query ---"
+        python -c "import torch; print('hip avail:', torch.cuda.is_available(), (torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'none'))" \
+          || echo "PROBE FAIL: hip device query rc=$?"
+        echo "--- probe 4: HIP compute, no override ---"
+        python -c "import torch; print('compute ok', torch.randn(4, device='cuda').sum().item())" \
+          || echo "PROBE FAIL: hip compute (no override) rc=$?"
+        echo "--- probe 5: HIP compute, HSA_OVERRIDE_GFX_VERSION=11.5.1 ---"
+        HSA_OVERRIDE_GFX_VERSION=11.5.1 python -c "import torch; print('compute ok', torch.randn(4, device='cuda').sum().item())" \
+          || echo "PROBE FAIL: hip compute (override 11.5.1) rc=$?"
+
+        echo ""
+        echo "=========================================="
         echo "STEP 8: Run Tests"
         echo "=========================================="
         # Pick the tiling scripts that match the NPU this runner actually has.

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -156,30 +156,6 @@ runs:
 
         echo ""
         echo "=========================================="
-        echo "STEP 7b: ROCm torch diagnostic probe"
-        echo "=========================================="
-        # Every example segfaults (exit -11) at import with no traceback; narrow
-        # down where ROCm torch dies. Each probe is non-fatal (|| echo) so we see
-        # all of them in one run. Order matters: the examples import torch before
-        # triton, so replicate that too.
-        echo "--- probe 1: bare torch import ---"
-        python -c "import torch; print('torch import ok', torch.__version__)" \
-          || echo "PROBE FAIL: bare torch import rc=$?"
-        echo "--- probe 2: torch then triton (example import order) ---"
-        python -c "import torch; import triton; from triton.backends.amd_triton_npu.driver import NPUDriver; print('torch+triton import ok')" \
-          || echo "PROBE FAIL: torch+triton import rc=$?"
-        echo "--- probe 3: HIP device query ---"
-        python -c "import torch; print('hip avail:', torch.cuda.is_available(), (torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'none'))" \
-          || echo "PROBE FAIL: hip device query rc=$?"
-        echo "--- probe 4: HIP compute, no override ---"
-        python -c "import torch; print('compute ok', torch.randn(4, device='cuda').sum().item())" \
-          || echo "PROBE FAIL: hip compute (no override) rc=$?"
-        echo "--- probe 5: HIP compute, HSA_OVERRIDE_GFX_VERSION=11.5.1 ---"
-        HSA_OVERRIDE_GFX_VERSION=11.5.1 python -c "import torch; print('compute ok', torch.randn(4, device='cuda').sum().item())" \
-          || echo "PROBE FAIL: hip compute (override 11.5.1) rc=$?"
-
-        echo ""
-        echo "=========================================="
         echo "STEP 8: Run Tests"
         echo "=========================================="
         # Pick the tiling scripts that match the NPU this runner actually has.
@@ -205,7 +181,8 @@ runs:
           echo "Auto-detected device architecture: $DEVICE"
         fi
         echo "Target device: $DEVICE"
-        python scripts/run_tests.py --device "$DEVICE" --verbose --timeout 1200
+        CUDA_VISIBLE_DEVICES="" HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" \
+          python scripts/run_tests.py --device "$DEVICE" --verbose --timeout 1200
 
         echo ""
         echo "=========================================="
@@ -222,10 +199,8 @@ runs:
         echo "=========================================="
         echo "STEP 10: LLM examples in hetero mode (iGPU + NPU)"
         echo "=========================================="
-        # Same gpt2/qwen examples, now in --backend hetero
-        # HSA_OVERRIDE_GFX_VERSION=11.5.1
-        # is required before any iGPU run so the rocm7.14 torch wheel targets
-        # gfx1151 (Strix Halo). 
+        # Same gpt2/qwen examples in --backend hetero (non-NPU ops on the iGPU).
+        # HSA_OVERRIDE_GFX_VERSION=11.5.1 is required for iGPU compute
         if [ "$DEVICE" = "aie2p" ]; then
           export HSA_OVERRIDE_GFX_VERSION=11.5.1
           hetero_rc=0

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -187,12 +187,37 @@ runs:
         echo "=========================================="
         echo "STEP 9: LLM examples in NPU-only mode"
         echo "=========================================="
-        # gpt2/qwen are the end-to-end iGPU-free gate. They default to --backend
-        # npu, so run_tests invokes them in npu mode; the iGPU is hidden here so a
-        # stray cuda/HIP touch fails the job rather than silently using the iGPU.
-        # transformers/numpy/ml_dtypes are their runtime deps (CPU-only, no ROCm);
+        # gpt2/qwen are the end-to-end iGPU-free gate. They default to --backend npu
         # if the HuggingFace hub is unreachable the examples exit 77 = SKIP.
         pip install --no-cache-dir transformers numpy ml_dtypes
         CUDA_VISIBLE_DEVICES="" HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" \
           python scripts/run_tests.py --device "$DEVICE" --verbose --timeout 1200 \
             -t gpt2 -t qwen2_5
+
+        echo ""
+        echo "=========================================="
+        echo "STEP 10: LLM examples in hetero mode (iGPU + NPU)"
+        echo "=========================================="
+        # Same gpt2/qwen examples, now in --backend hetero
+        # HSA_OVERRIDE_GFX_VERSION=11.5.1
+        # is required before any iGPU run so the rocm7.14 torch wheel targets
+        # gfx1151 (Strix Halo). 
+        if [ "$DEVICE" = "aie2p" ]; then
+          export HSA_OVERRIDE_GFX_VERSION=11.5.1
+          hetero_rc=0
+          for ex in gpt2 qwen2_5; do
+            echo "--- hetero: $ex ---"
+            entry=$(ls examples/$ex/*_inference.py | head -1)
+            ( cd "examples/$ex" && python "$(basename "$entry")" --backend hetero --max-tokens 0 --verbose )
+            rc=$?
+            if [ "$rc" -eq 77 ]; then
+              echo "SKIP: $ex (exit 77)"
+            elif [ "$rc" -ne 0 ]; then
+              echo "FAIL: $ex (exit $rc)"
+              hetero_rc=1
+            fi
+          done
+          exit $hetero_rc
+        else
+          echo "Skipping hetero run: gpt2/qwen are npu2-only (device=$DEVICE)."
+        fi

--- a/amd_triton_npu/backend/__init__.py
+++ b/amd_triton_npu/backend/__init__.py
@@ -1,14 +1,20 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-# Force mlir-air's statically-linked LLVM to load before any ROCm SDK LLVM.
-# A ROCm PyTorch install (e.g. TheRock/gfx1151) transitively pulls in its own
-# libLLVM.so.23 via libamdhip64 -> libhipblaslt. Under ELF first-loaded-wins
-# symbol resolution, whichever LLVM loads first wins the global namespace; if
-# ROCm's wins, mlir-air's libAirAggregateCAPI.so constructor binds the wrong
-# LLVM globals and segfaults (issue #102). Importing air's own LLVM-linked
-# bindings here makes mlir-air's symbols win before triton_shared is loaded.
+# air statically links LLVM; a ROCm PyTorch install pulls in its own
+# libLLVM.so.23. When a script imports torch before triton (as every example
+# does), ROCm's LLVM wins the global namespace and air's constructor binds the
+# wrong globals and segfaults (issue #102). Load air's bindings with
+# RTLD_DEEPBIND so air resolves its own LLVM regardless of torch.
 try:
-    import air._mlir_libs._mlir  # noqa: F401
+    import os
+    import sys
+
+    _prev_flags = sys.getdlopenflags()
+    sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL | os.RTLD_DEEPBIND)
+    try:
+        import air._mlir_libs._mlir  # noqa: F401
+    finally:
+        sys.setdlopenflags(_prev_flags)
 except Exception:
     pass

--- a/ci/docker-based/Dockerfile
+++ b/ci/docker-based/Dockerfile
@@ -4,6 +4,11 @@
 # triton-xdna dev container with GitHub Actions runner
 # To run with NPU device passthrough, use:
 # docker run -v /dev/accel/accel0:/dev/accel/accel0 --device-cgroup-rule 'c 261:* rmw' --ulimit memlock=-1:-1 <image>
+# The heterogeneous examples (examples/gpt2, examples/qwen2_5) also run part of
+# the model on the iGPU via ROCm, so those runs additionally need the iGPU
+# devices (/dev/kfd, /dev/dri) passed through. The ROCm userspace ships in the
+# torch wheel, so no host ROCm mount is required. See test_docker_ci.sh /
+# loop_docker_ci.sh for the full device set.
 
 # To build this docker, run from the repo root:
 # docker build -f ci/docker-based/Dockerfile -t triton-xdna-dev-github-runner
@@ -21,6 +26,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # with "error while loading shared libraries" and every XRT query that
     # shells out to it silently reports no NPU.
     libboost-filesystem1.83.0 libboost-program-options1.83.0 \
+    # Runtime deps of the host-mounted ROCm stack, needed by the heterogeneous
+    # examples that run part of the model on the iGPU. Without libelf1, rocminfo
+    # and torch's HIP init fail with "libelf.so.1: cannot open shared object
+    # file"; libnuma/libdrm are pulled in by the ROCm HIP runtime.
+    libelf1 libnuma1 libdrm2 libdrm-amdgpu1 \
     # Required by MHA kernel
     llvm-18 \
     # Clang toolchain for Triton build

--- a/ci/docker-based/loop_docker_ci.sh
+++ b/ci/docker-based/loop_docker_ci.sh
@@ -34,6 +34,14 @@ get_registration_token() {
   echo "${TOKEN}"
 }
 
+# iGPU passthrough for the heterogeneous examples (examples/gpt2, qwen2_5),
+# which run part of the model on the iGPU via ROCm. Docker needs numeric gids,
+# and the render gid is host-specific, so derive both at runtime instead of
+# hard-coding. (The ROCm runtime is bundled in the torch wheel, so no host
+# ROCm mount is required.)
+RENDER_GID="$(getent group render | cut -d: -f3)"
+VIDEO_GID="$(getent group video | cut -d: -f3)"
+
 while true; do
     DATE=$(printf '%(%Y_%m_%d_%H_%M_%S)T')
     NAME="ci-run-${DATE}"
@@ -47,9 +55,13 @@ while true; do
         --rm \
         --name "${NAME}" \
         --device-cgroup-rule 'c 261:* rmw' \
+        --device /dev/accel/accel0 \
+        --device /dev/kfd \
+        --device /dev/dri \
+        --group-add "${RENDER_GID}" \
+        --group-add "${VIDEO_GID}" \
         --ulimit memlock=-1:-1 \
         -v /opt/xilinx/xrt:/opt/xilinx/xrt:ro \
-        -v /dev/accel/accel0:/dev/accel/accel0 \
         -v /srv:/srv:ro \
         -e GITHUB_RUNNER_TOKEN="${TOKEN}" \
         -e GITHUB_OWNER="${GITHUB_OWNER}" \

--- a/ci/docker-based/test_docker_ci.sh
+++ b/ci/docker-based/test_docker_ci.sh
@@ -10,15 +10,27 @@ GITHUB_REPO="Triton-XDNA"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GITHUB_PAT=$(cat "${SCRIPT_DIR}/secret_github_token")
 
+# iGPU passthrough for the heterogeneous examples (examples/gpt2, qwen2_5),
+# which run part of the model on the iGPU via ROCm. Docker needs numeric gids,
+# and the render gid is host-specific, so derive both at runtime instead of
+# hard-coding. (The ROCm runtime is bundled in the torch wheel, so no host
+# ROCm mount is required.)
+RENDER_GID="$(getent group render | cut -d: -f3)"
+VIDEO_GID="$(getent group video | cut -d: -f3)"
+
 DATE=$(printf '%(%Y_%m_%d_%H_%M_%S)T')
 NAME="ci-run-${DATE}"
 docker run \
     --rm \
     --name "${NAME}" \
     --device-cgroup-rule 'c 261:* rmw' \
+    --device /dev/accel/accel0 \
+    --device /dev/kfd \
+    --device /dev/dri \
+    --group-add "${RENDER_GID}" \
+    --group-add "${VIDEO_GID}" \
     --ulimit memlock=-1:-1 \
     -v /opt/xilinx/xrt:/opt/xilinx/xrt:ro \
-    -v /dev/accel/accel0:/dev/accel/accel0 \
     -v /srv:/srv:ro \
     -e GITHUB_PAT="${GITHUB_PAT}" \
     -e GITHUB_OWNER="${GITHUB_OWNER}" \

--- a/examples/gpt2/README.md
+++ b/examples/gpt2/README.md
@@ -30,7 +30,10 @@ pip install transformers
 # torch: a CPU build is enough for `npu` and `reference`; use a ROCm build for
 # the gpu/hetero modes (adjust the ROCm version to match your install).
 pip install torch --index-url https://download.pytorch.org/whl/cpu
-# pip install torch --index-url https://download.pytorch.org/whl/rocm6.2
+# ROCm build: rocm7.2 has native gfx1151 (Strix Halo) kernels; older wheels
+# (e.g. rocm6.2) lack them and fail with "HIP error: invalid device function"
+# unless you set HSA_OVERRIDE_GFX_VERSION.
+# pip install torch --index-url https://download.pytorch.org/whl/test/rocm7.2
 
 # Environment setup (required for NPU/hetero modes)
 source /opt/xilinx/xrt/setup.sh

--- a/examples/qwen2_5/README.md
+++ b/examples/qwen2_5/README.md
@@ -26,7 +26,10 @@ pip install transformers
 # torch: a CPU build is enough for `npu` and `reference`; use a ROCm build for
 # the gpu/hetero modes (adjust the ROCm version to match your install).
 pip install torch --index-url https://download.pytorch.org/whl/cpu
-# pip install torch --index-url https://download.pytorch.org/whl/rocm6.2
+# ROCm build: rocm7.2 has native gfx1151 (Strix Halo) kernels; older wheels
+# (e.g. rocm6.2) lack them and fail with "HIP error: invalid device function"
+# unless you set HSA_OVERRIDE_GFX_VERSION.
+# pip install torch --index-url https://download.pytorch.org/whl/test/rocm7.2
 
 # Environment setup (required for NPU/hetero modes)
 source /opt/xilinx/xrt/setup.sh


### PR DESCRIPTION
## Summary

  The `gpt2` and `qwen2_5` examples run part of the model on the iGPU via ROCm
  (the LM head/attention always run on GPU, even in `--backend npu`), and the
  `hetero` backend splits work across the iGPU and NPU. This wires the CI to
  support that: pass the iGPU into the docker runner, install a ROCm torch build,
  and exercise the examples end to end in hetero mode.

  ## Changes

  **Docker CI (iGPU passthrough)**
  - `ci/docker-based/Dockerfile`: add `libelf1`/`libnuma1`/`libdrm2`/`libdrm-amdgpu1`,
    the runtime libs the ROCm torch wheel loads (without `libelf1`, torch HIP init
    and `rocminfo` fail on `libelf.so.1`). The rest of the ROCm userspace ships in
    the wheel, so no host ROCm mount is needed.
  - `test/loop` docker scripts: pass `/dev/kfd` and `/dev/dri`, add the render/video
    groups (derived at runtime since the render gid is host-specific), and move the
    NPU to `--device`.

  **GitHub Actions (ROCm torch + hetero test)**
  - `build` action: swap the CPU torch wheel for the `rocm7.14` wheel, which has
    native gfx1151 (Strix Halo) kernels.
  - `test` action: add a hetero step (STEP 10) running `gpt2`/`qwen2_5` in
    `--backend hetero` (iGPU + NPU). Gated to `aie2p` since these examples are
    npu2-only, sets `HSA_OVERRIDE_GFX_VERSION=11.5.1` before the run, and treats
    exit 77 as SKIP (HuggingFace hub unreachable). The existing NPU-only gate
    (STEP 9) is unchanged.

  **Docs**
  - `gpt2`/`qwen2_5` READMEs: note the `rocm7.14`/gfx1151 torch wheel for the
    gpu/hetero modes.